### PR TITLE
Mount Hail tokens in user job containers

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -488,7 +488,8 @@ class ServiceBackend(Backend):
                                     timeout=job._timeout,
                                     gcsfuse=job._gcsfuse if len(job._gcsfuse) > 0 else None,
                                     env=env_vars,
-                                    requester_pays_project=batch.requester_pays_project)
+                                    requester_pays_project=batch.requester_pays_project,
+                                    mount_tokens=True)
 
             n_jobs_submitted += 1
 


### PR DESCRIPTION
This is necessary for submitting a "nested batch" from the user's job.