### PR TITLE
Fix conda development versions format

### DIFF
--- a/.github/workflows/condarize.yaml
+++ b/.github/workflows/condarize.yaml
@@ -32,7 +32,7 @@ jobs:
           MKFILE=hail/Makefile
           MAJOR_MINOR=$(grep -Po 'HAIL_MAJOR_MINOR_VERSION := \K.*(?=)' ${MKFILE})
           PATCH=$(grep -Po 'HAIL_PATCH_VERSION := \K.*(?=)' ${MKFILE})
-          VERSION=${MAJOR_MINOR}.${PATCH}-${GITHUB_SHA:0:7}
+          VERSION=${MAJOR_MINOR}.${PATCH}.dev${GITHUB_SHA:0:7}
           cat conda/hail/meta-template.yaml \
           | sed s/{version}/${VERSION}/ > conda/hail/meta.yaml
 


### PR DESCRIPTION
Conda follows PEP-0440 for version tags and doesn't allow dashes in them. Changing for formatting of development releases to `0.2.61.dev0c034e0`, following the [PEP-0440 guideline](https://www.python.org/dev/peps/pep-0440/#developmental-releases).