### PR TITLE
Conda pkg: prepare meta.yaml in a separate ubuntu job

### DIFF
--- a/.github/workflows/condarize.yaml
+++ b/.github/workflows/condarize.yaml
@@ -32,7 +32,7 @@ jobs:
           MKFILE=hail/Makefile
           MAJOR_MINOR=$(grep -Po 'HAIL_MAJOR_MINOR_VERSION := \K.*(?=)' ${MKFILE})
           PATCH=$(grep -Po 'HAIL_PATCH_VERSION := \K.*(?=)' ${MKFILE})
-          VERSION=${MAJOR_MINOR}.${PATCH}-${GITHUB_SHA:0:7}
+          VERSION=${MAJOR_MINOR}.${PATCH}.dev${GITHUB_SHA:0:7}
           cat conda/hail/meta-template.yaml \
           | sed s/{version}/${VERSION}/ > conda/hail/meta.yaml
 

--- a/.github/workflows/condarize.yaml
+++ b/.github/workflows/condarize.yaml
@@ -1,8 +1,6 @@
 name: CI
-on:
-  push:
-    branches:
-      - main
+on: [push, pull_request]
+
 jobs:
   set_conda_pkg_version:
     # For tag pushes, we want to assure only the tag event triggers CI, not the accompanying commit:
@@ -63,6 +61,7 @@ jobs:
         run: conda build conda/hail
 
       - name: Upload to anaconda package repository
+        if: github.ref == 'refs/heads/main'
         run: |
           anaconda -t ${{ secrets.ANACONDA_TOKEN }} \
           upload ${CONDA_PREFIX}/conda-bld/**/*.tar.bz2

--- a/.github/workflows/condarize.yaml
+++ b/.github/workflows/condarize.yaml
@@ -1,8 +1,7 @@
-name: CI
+name: Condarize
 on: [push, pull_request]
-
 jobs:
-  set_conda_pkg_version:
+  set-conda-pkg-version:
     # For tag pushes, we want to assure only the tag event triggers CI, not the accompanying commit:
     if: "! startsWith(github.event.head_commit.message, 'Bump ') || startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
@@ -24,10 +23,10 @@ jobs:
           name: meta.yaml
           path: conda/hail/meta.yaml
 
-  condarize:
+  build-publish:
     # For tag pushes, we want to assure only the tag event triggers CI, not the accompanying commit:
     if: "! startsWith(github.event.head_commit.message, 'Bump ') || startsWith(github.ref, 'refs/tags/')"
-    needs: set_conda_pkg_version
+    needs: set-conda-pkg-version
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/condarize.yaml
+++ b/.github/workflows/condarize.yaml
@@ -44,9 +44,6 @@ jobs:
           name: meta.yaml
           path: conda/hail/
 
-      - name: Test artefacts
-        run: cat conda/hail/meta.yaml
-
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: buildenv

--- a/.github/workflows/condarize.yaml
+++ b/.github/workflows/condarize.yaml
@@ -1,12 +1,35 @@
 name: CI
-on: 
+on:
   push:
     branches:
       - main
 jobs:
-  build-test-publish:
+  set_conda_pkg_version:
     # For tag pushes, we want to assure only the tag event triggers CI, not the accompanying commit:
     if: "! startsWith(github.event.head_commit.message, 'Bump ') || startsWith(github.ref, 'refs/tags/')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Fix meta YAML
+        run: |
+          MKFILE=hail/Makefile
+          MAJOR_MINOR=$(grep -Po 'HAIL_MAJOR_MINOR_VERSION := \K.*(?=)' ${MKFILE})
+          PATCH=$(grep -Po 'HAIL_PATCH_VERSION := \K.*(?=)' ${MKFILE})
+          VERSION=${MAJOR_MINOR}.${PATCH}.dev${GITHUB_SHA:0:7}
+          cat conda/hail/meta-template.yaml \
+          | sed s/{version}/${VERSION}/ > conda/hail/meta.yaml
+
+      - name: Upload meta YAML for build job
+        uses: actions/upload-artifact@v2
+        with:
+          name: meta.yaml
+          path: conda/hail/meta.yaml
+
+  condarize:
+    # For tag pushes, we want to assure only the tag event triggers CI, not the accompanying commit:
+    if: "! startsWith(github.event.head_commit.message, 'Bump ') || startsWith(github.ref, 'refs/tags/')"
+    needs: set_conda_pkg_version
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -16,6 +39,15 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@main
+
+      - name: Download meta YAML
+        uses: actions/download-artifact@v2
+        with:
+          name: meta.yaml
+          path: conda/hail/
+
+      - name: Test artefacts
+        run: cat conda/hail/meta.yaml
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -27,19 +59,10 @@ jobs:
       - name: Setup build env
         run: conda install pip conda-build anaconda-client
 
-      - name: Fix version
-        run: |
-          MKFILE=hail/Makefile
-          MAJOR_MINOR=$(grep -Po 'HAIL_MAJOR_MINOR_VERSION := \K.*(?=)' ${MKFILE})
-          PATCH=$(grep -Po 'HAIL_PATCH_VERSION := \K.*(?=)' ${MKFILE})
-          VERSION=${MAJOR_MINOR}.${PATCH}.dev${GITHUB_SHA:0:7}
-          cat conda/hail/meta-template.yaml \
-          | sed s/{version}/${VERSION}/ > conda/hail/meta.yaml
-
       - name: Build package
         run: conda build conda/hail
 
       - name: Upload to anaconda package repository
         run: |
-          anaconda -t ${{ secrets.ANACONDA_TOKEN }} --force \
+          anaconda -t ${{ secrets.ANACONDA_TOKEN }} \
           upload ${CONDA_PREFIX}/conda-bld/**/*.tar.bz2


### PR DESCRIPTION
We use grep to fix the version tag in the conda recipe file. However, the MacOS job failed because the grep is not GNU-distributed and doesn't have perl regex features. 

One solution would be to replace grep with something else; however, I'm going with another one: move the recipe manipulation into a separate job that would run on Ubuntu; that job then would share the prepared recipe with the build-publish jobs.