### PR TITLE
Run GH workflow (to build conda package) on tag pushes only

### DIFF
--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -2,7 +2,7 @@ name: Condarise
 on: [push, pull_request]
 jobs:
   set-conda-pkg-version:
-    # For tag pushes, we want to assure only the tag event triggers CI, not the accompanying commit:
+    # Run for tags only
     if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
     steps:
@@ -24,7 +24,7 @@ jobs:
           path: conda/hail/meta.yaml
 
   build-publish:
-    # For tag pushes, we want to assure only the tag event triggers CI, not the accompanying commit:
+    # Run for tags only
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: set-conda-pkg-version
     strategy:

--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -1,9 +1,9 @@
-name: Condarize
+name: Condarise
 on: [push, pull_request]
 jobs:
   set-conda-pkg-version:
     # For tag pushes, we want to assure only the tag event triggers CI, not the accompanying commit:
-    if: "! startsWith(github.event.head_commit.message, 'Bump ') || startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
@@ -25,7 +25,7 @@ jobs:
 
   build-publish:
     # For tag pushes, we want to assure only the tag event triggers CI, not the accompanying commit:
-    if: "! startsWith(github.event.head_commit.message, 'Bump ') || startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/')"
     needs: set-conda-pkg-version
     strategy:
       matrix:


### PR DESCRIPTION
The conda package version is still going to be formatted as `<hail-version>.dev<git-hash>`, regardless of tags.