### PR TITLE
Conda pkg: fix for hailctl

### DIFF
--- a/conda/hail/build.sh
+++ b/conda/hail/build.sh
@@ -3,5 +3,5 @@
 # Build instructions
 # https://hail.is/docs/0.2/getting_started_developing.html#requirements
 pushd $SRC_DIR/hail
-make install HAIL_COMPILE_NATIVES='build' -j ${CPU_COUNT}
+make install HAIL_COMPILE_NATIVES='build' -j ${CPU_COUNT} SKIP_UPLOAD_ARTIFACTS=1
 popd

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -215,6 +215,7 @@ UPLOAD_RETENTION = gsutil -m retention temp set "$(cloud_base)/*"
 endif
 
 ifdef SKIP_UPLOAD_ARTIFACTS
+DEV_CLARIFIER =
 CLOUD_SUB_FOLDER := $(HAIL_PIP_VERSION)
 endif
 

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -214,6 +214,10 @@ CLOUD_SUB_FOLDER := $(HAIL_PIP_VERSION)
 UPLOAD_RETENTION = gsutil -m retention temp set "$(cloud_base)/*"
 endif
 
+ifdef SKIP_UPLOAD_ARTIFACTS
+CLOUD_SUB_FOLDER := $(HAIL_PIP_VERSION)
+endif
+
 HAILCTL_BUCKET_BASE ?= gs://hail-common/hailctl/dataproc
 
 cloud_base := $(HAILCTL_BUCKET_BASE)/$(DEV_CLARIFIER)$(CLOUD_SUB_FOLDER)
@@ -255,7 +259,11 @@ install-on-cluster: $(WHEEL)
 	$(PIP) install $(WHEEL) --no-deps
 
 .PHONY: install-hailctl
+ifdef SKIP_UPLOAD_ARTIFACTS
+install-hailctl: install
+else
 install-hailctl: install upload-artifacts
+endif
 
 .PHONY: test-dataproc
 test-dataproc: install-hailctl


### PR DESCRIPTION
Added a flag into the Makefile to skip uploading artefacts to a bucket when building Hail, and instead point to the official release ones. This fixes `hailctl dataproc` commands.

If we ever get to change files like `init_notebook.py` in our fork, we could probably create our own public bucket. Or perhaps create it now?