### PR TITLE
Upload to anaconda

### DIFF
--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -57,7 +57,6 @@ jobs:
         run: conda build conda/hail
 
       - name: Upload to anaconda package repository
-        if: github.ref == 'refs/heads/main'
         run: |
           anaconda -t ${{ secrets.ANACONDA_TOKEN }} \
           upload ${CONDA_PREFIX}/conda-bld/**/*.tar.bz2


### PR DESCRIPTION
A small fix to re-enable uploading the conda package to anaconda on tag pushes.