### PR TITLE
Add query graceful shutdown

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -2,7 +2,7 @@ aiodns==2.0.0
 aiodocker==0.17.0
 aiohttp-jinja2==1.1.1
 aiohttp-session==2.7.0
-aiohttp==3.6.0
+aiohttp==3.7.3
 aiomysql==0.0.20
 aioredis==1.3.1
 async-timeout==3.0.1

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: query
         hail.is/sha: "{{ code.sha }}"
     spec:
+      terminationGracePeriodSeconds: 28800  # 8 hours
       serviceAccountName: query
 {% if deploy %}
       priorityClassName: production

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -249,7 +249,10 @@ async def on_cleanup(app):
 
 
 async def on_shutdown(app):
-    await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
+    remaining_tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    log.info(f"On shutdown request received, with {len(remaining_tasks)} tasks left")
+    await asyncio.gather(*remaining_tasks)
+    log.info("Tasks have all completed.")
 
 
 def run():

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -229,6 +229,10 @@ async def on_cleanup(app):
     await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
 
 
+async def on_shutdown(app):
+    await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
+
+
 def run():
     app = web.Application()
 
@@ -238,6 +242,7 @@ def run():
 
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)
+    app.on_shutdown.append(on_shutdown)
 
     deploy_config = get_deploy_config()
     web.run_app(

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -196,25 +196,6 @@ async def set_flag(request, userdata):  # pylint: disable=unused-argument
     return java_to_web_response(jresp)
 
 
-@routes.get('/api/v1alpha/wait')
-async def wait_seconds(request):
-    """
-    Wait query.duration seconds before returning the request.
-    """
-    duration = request.query.get('duration')
-    try:
-        duration = int(duration)
-    except Exception as e:
-        return web.json_response({
-            'error': f'Invalid parameter duration "{duration}": {e}',
-        }, status=422)
-
-    await asyncio.sleep(int(duration))
-    e = os.getenv("TEST_VALUE", "None")
-    # remove_request_from_weakref_set(request)
-    return web.json_response({"d": f"You waited '{duration}' seconds!!", "env": e})
-
-
 async def on_startup(app):
     thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=16)
     app['thread_pool'] = thread_pool

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -226,13 +226,15 @@ async def on_startup(app):
 
 async def on_cleanup(app):
     del app['k8s_client']
-    await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
+    await asyncio.wait(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
 
 
 async def on_shutdown(app):
+    # Filter the asyncio.current_task(), because if we await
+    # the current task we'll end up in a deadlock
     remaining_tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
     log.info(f"On shutdown request received, with {len(remaining_tasks)} remaining tasks")
-    await asyncio.gather(*remaining_tasks)
+    await asyncio.wait(*remaining_tasks)
     log.info("All tasks on shutdown have completed")
 
 

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -196,6 +196,25 @@ async def set_flag(request, userdata):  # pylint: disable=unused-argument
     return java_to_web_response(jresp)
 
 
+@routes.get('/api/v1alpha/wait')
+async def wait_seconds(request):
+    """
+    Wait query.duration seconds before returning the request.
+    """
+    duration = request.query.get('duration')
+    try:
+        duration = int(duration)
+    except Exception as e:
+        return web.json_response({
+            'error': f'Invalid parameter duration "{duration}": {e}',
+        }, status=422)
+
+    await asyncio.sleep(int(duration))
+    e = os.getenv("TEST_VALUE", "None")
+    # remove_request_from_weakref_set(request)
+    return web.json_response({"d": f"You waited '{duration}' seconds!!", "env": e})
+
+
 async def on_startup(app):
     thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=16)
     app['thread_pool'] = thread_pool

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -231,9 +231,9 @@ async def on_cleanup(app):
 
 async def on_shutdown(app):
     remaining_tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-    log.info(f"On shutdown request received, with {len(remaining_tasks)} tasks left")
+    log.info(f"On shutdown request received, with {len(remaining_tasks)} remaining tasks")
     await asyncio.gather(*remaining_tasks)
-    log.info("Tasks have all completed.")
+    log.info("All tasks on shutdown have completed")
 
 
 def run():


### PR DESCRIPTION
- Add `terminationGracePeriodSeconds` to query service
- Implement `app.on_shutdown` signal handler to wait for all asyncio tasks to complete before returning.
- Upgrade `aiohttp == 0.7.3` to address tasks being cancelled before the on_shutdown method is called: https://github.com/aio-libs/aiohttp/issues/3593

## Testing

- Adding a "wait `n` seconds" method that slept for n seconds, and returned the value of an environment variable. This environment variable meant I could track which version of the deployment my script ran against.
- Taking the `deploy.yaml` from the `deploy query` step of the dev deploy, adding the `TEST_VALUE` environment variable with some value and saving it as `new-deploy.yaml`
- Issuing the first wait request (for 50 seconds) (`https://internal.hail.populationgenomics.org.au/$NAMESPACE/query/api/v1alpha/wait?duration=50`)
- Issuing the new deploy with:
    ```bash
    kubectl -n $NAMESPACE apply -f new-deploy.yaml
    kubectl -n $NAMESPACE rollout status --timeout=10m deployment query
    ```
- When the new pod is created (seen with `kubectl --namespace $NAMESPACE get pod`), issue the second request to the wait method.
- If all goes well, you should have:
    - termination logs like those below,
    - the first request successfully fulfilled with the response of env value being None (filled by the first pod)
    - The second request successfully filled, but has the value of the environment value, the one you set in the deploy.yaml (it got scheduled to the new node)

Termination logs:

```
{"severity": "INFO", "levelname": "INFO", "asctime": "2021-02-24 23:22:40,472", "filename": "query.py", "funcNameAndLine": "on_shutdown:253", "message": "On shutdown request received, with 2 tasks left", "hail_log": 1}
++ term
++ kill -TERM 7
+ true
+ '[' no == yes ']'
+ trap - SIGTERM SIGINT
+ wait 7
{"severity": "INFO", "levelname": "INFO", "asctime": "2021-02-24 23:23:26,004", "filename": "hail_logging.py", "funcNameAndLine": "log:40", "message": "https GET /michaelfranklin/query/api/v1alpha/wait done in 50.029999999998836s: 200", "remote_address": "10.28.127.3", "request_start_time": "[24/Feb/2021:23:22:35 +0000]", "request_duration": 50.029999999998836, "response_status": 200, "x_real_ip": "124.170.20.28", "hail_log": 1}
{"severity": "INFO", "levelname": "INFO", "asctime": "2021-02-24 23:23:26,005", "filename": "query.py", "funcNameAndLine": "on_shutdown:255", "message": "Tasks have all completed.", "hail_log": 1}
```

Duration endpoint
```python
@routes.get('/api/v1alpha/wait')
async def wait_seconds(request):
    """
    Wait query.duration seconds before returning the request.
    """
    duration = request.query.get('duration')
    try:
        duration = int(duration)
    except Exception as e:
        return web.json_response({
            'error': f'Invalid parameter duration "{duration}": {e}',
        }, status=422)

    await asyncio.sleep(int(duration))
    e = os.getenv("TEST_VALUE", "None")
    return web.json_response({"d": f"You waited '{duration}' seconds!!", "env": e})
```