### PR TITLE
[conda] build on push to main

### DIFF
--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -1,9 +1,10 @@
 name: Condarise
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
 jobs:
   set-conda-pkg-version:
-    # Run for tags only
-    if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
@@ -24,8 +25,6 @@ jobs:
           path: conda/hail/meta.yaml
 
   build-publish:
-    # Run for tags only
-    if: "startsWith(github.ref, 'refs/tags/')"
     needs: set-conda-pkg-version
     strategy:
       matrix:


### PR DESCRIPTION
Change triggering conda builds on pushes to `main` rather than on tag pushes.