### PR TITLE
Gitignore */hail.jar and *.dylib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ hs_err_pid*.log
 GPATH
 GRTAGS
 GTAGS
-hail/prebuilt/lib/darwin/libboot.dylib
-hail/prebuilt/lib/darwin/libhail.dylib
-query/hail.jar
+*.dylib
+*/hail.jar
 infra/.terraform.lock.hcl


### PR DESCRIPTION
* `hail.jar` can be created in several subfolders, so gitignoring with a wildcard as `*/hail.jar`
* also wildcarding the `.dylib` files as well as it's not desirable to commit any of them