### PR TITLE
Fix conda version tag

### DIFF
--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -1,5 +1,8 @@
 name: Condarise
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
 jobs:
   build-publish:
     strategy:

--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -19,6 +19,7 @@ jobs:
         run: |
           make -C hail python-version-info
           VERSION=$(cat hail/python/hail/hail_version)
+          VERSION=${VERSION/-/.dev}
           cat conda/hail/meta-template.yaml \
           | sed s/{version}/${VERSION}/ > conda/hail/meta.yaml
 

--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -1,8 +1,5 @@
 name: Condarise
-on:
-  push:
-    branches:
-      - main
+on: [push, pull_request]
 jobs:
   build-publish:
     strategy:


### PR DESCRIPTION
It's no longer exact same format as `hailctl version` returns, but at least the git hash is the same.

0.2.62-9d69512338f7 (`hailctl version`)
0.2.62.dev9d69512338f7 (conda package tag)