### PR TITLE
Temporarily hardcode DOCKER_ROOT_IMAGE to get ci working

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2296,7 +2296,7 @@ steps:
      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
-     export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_ROOT_IMAGE="australia-southeast1-docker.pkg.dev/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2364,7 +2364,7 @@ steps:
      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
-     export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_ROOT_IMAGE="australia-southeast1-docker.pkg.dev/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2432,7 +2432,7 @@ steps:
      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
-     export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_ROOT_IMAGE="australia-southeast1-docker.pkg.dev/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2500,7 +2500,7 @@ steps:
      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
-     export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_ROOT_IMAGE="australia-southeast1-docker.pkg.dev/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2568,7 +2568,7 @@ steps:
      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
-     export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_ROOT_IMAGE="australia-southeast1-docker.pkg.dev/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2785,7 +2785,7 @@ steps:
      export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=0
-     export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_ROOT_IMAGE="australia-southeast1-docker.pkg.dev/ubuntu:18.04"
      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
      hailctl config set batch/billing_project test
      hailctl config set batch/bucket cpg-hail-test
@@ -2836,7 +2836,7 @@ steps:
      export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=1
-     export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_ROOT_IMAGE="australia-southeast1-docker.pkg.dev/ubuntu:18.04"
      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
      hailctl config set batch/billing_project test
      hailctl config set batch/bucket cpg-hail-test
@@ -2887,7 +2887,7 @@ steps:
      export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=2
-     export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_ROOT_IMAGE="australia-southeast1-docker.pkg.dev/ubuntu:18.04"
      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
      hailctl config set batch/billing_project test
      hailctl config set batch/bucket cpg-hail-test
@@ -2938,7 +2938,7 @@ steps:
      export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=3
-     export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_ROOT_IMAGE="australia-southeast1-docker.pkg.dev/ubuntu:18.04"
      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
      hailctl config set batch/billing_project test
      hailctl config set batch/bucket cpg-hail-test
@@ -2989,7 +2989,7 @@ steps:
      export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=4
-     export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_ROOT_IMAGE="australia-southeast1-docker.pkg.dev/ubuntu:18.04"
      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
      hailctl config set batch/billing_project test
      hailctl config set batch/bucket cpg-hail-test


### PR DESCRIPTION
`prod_deploy` pulls the branch and checks the updated `build.yaml`, but with an outdated `ci/build.py` code, so it doesn't know about `global.docker_root_image` variable. Hardcoding DOCKER_ROOT_IMAGE as a temporary fix.