### PR TITLE
[prod deploy]: show batch url in the terminal

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -150,7 +150,8 @@ async def prod_deploy(request, unused_userdata):
     watched_branch.sha = 'HEAD'
     await watched_branch._start_deploy(request.app['batch_client'], steps)
 
-    url = deploy_config.external_url('ci', '/batches')
+    batch_id = watched_branch.deploy_batch.id
+    url = deploy_config.external_url('ci', f'/batches/{batch_id}')
     return web.Response(text=f'{url}\n')
 
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -148,7 +148,7 @@ async def prod_deploy(request, unused_userdata):
         0, FQBranch.from_short_str('populationgenomics/hail:main'), True
     )
     watched_branch.sha = 'HEAD'
-    await watched_branch._start_deploy(request.app['batch_client'], steps)
+    await watched_branch._start_deploy(app['batch_client'], steps)
 
     batch_id = watched_branch.deploy_batch.id
     url = deploy_config.external_url('ci', f'/batches/{batch_id}')


### PR DESCRIPTION
Currently, it prints just the URL to all batches 

```
$ curl -X POST -H "Authorization: Bearer $(jq -r .default ~/.hail/tokens.json)" \
    -H "Content-Type:application/json" \
    -d '{"steps": ["deploy_batch"]}' \
    https://ci.hail.populationgenomics.org.au/api/v1alpha/prod_deploy
https://ci.hail.populationgenomics.org.au/batches
```

This PR should make it print the URL to the specific batch.