### PR TITLE
Add docker_root_prefix into build.yaml

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2258,6 +2258,7 @@ steps:
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
      export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_PREFIX="{{ global.docker_prefix }}"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2326,6 +2327,7 @@ steps:
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
      export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_PREFIX="{{ global.docker_prefix }}"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2394,6 +2396,7 @@ steps:
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
      export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_PREFIX="{{ global.docker_prefix }}"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2462,6 +2465,7 @@ steps:
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
      export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_PREFIX="{{ global.docker_prefix }}"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2530,6 +2534,7 @@ steps:
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
      export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_PREFIX="{{ global.docker_prefix }}"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2747,6 +2752,7 @@ steps:
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=0
      export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_PREFIX="{{ global.docker_prefix }}"
      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
      hailctl config set batch/billing_project test
      hailctl config set batch/bucket cpg-hail-test
@@ -2798,6 +2804,7 @@ steps:
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=1
      export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_PREFIX="{{ global.docker_prefix }}"
      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
      hailctl config set batch/billing_project test
      hailctl config set batch/bucket cpg-hail-test
@@ -2849,6 +2856,7 @@ steps:
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=2
      export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_PREFIX="{{ global.docker_prefix }}"
      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
      hailctl config set batch/billing_project test
      hailctl config set batch/bucket cpg-hail-test
@@ -2900,6 +2908,7 @@ steps:
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=3
      export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_PREFIX="{{ global.docker_prefix }}"
      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
      hailctl config set batch/billing_project test
      hailctl config set batch/bucket cpg-hail-test
@@ -2951,6 +2960,7 @@ steps:
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=4
      export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+     export DOCKER_PREFIX="{{ global.docker_prefix }}"
      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
      hailctl config set batch/billing_project test
      hailctl config set batch/bucket cpg-hail-test


### PR DESCRIPTION
It's needed for batch-driver when running prod_deploy. Adding into other places for consistency.