### PR TITLE
Dataproc: support pyfiles in zip, and --region option

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/stop.py
+++ b/hail/python/hailtop/hailctl/dataproc/stop.py
@@ -5,6 +5,7 @@ def init_parser(parser):
     parser.add_argument('name', type=str, help='Cluster name.')
     parser.add_argument('--async', action='store_true', dest='asink',
                         help="Do not wait for cluster deletion.")
+    parser.add_argument('--region', help='Region.')
     parser.add_argument('--dry-run', action='store_true',
                         help="Print gcloud dataproc command, but don't run it.")
 
@@ -12,7 +13,14 @@ def init_parser(parser):
 def main(args, pass_through_args):
     print("Stopping cluster '{}'...".format(args.name))
 
-    cmd = ['dataproc', 'clusters', 'delete', '--quiet', args.name]
+    cmd = [
+        'dataproc', 
+        'clusters', 
+        'delete', 
+        '--region={}'.format(args.region), 
+        '--quiet', 
+        args.name
+    ]
     if args.asink:
         cmd.append('--async')
 

--- a/hail/python/hailtop/hailctl/dataproc/stop.py
+++ b/hail/python/hailtop/hailctl/dataproc/stop.py
@@ -5,7 +5,7 @@ def init_parser(parser):
     parser.add_argument('name', type=str, help='Cluster name.')
     parser.add_argument('--async', action='store_true', dest='asink',
                         help="Do not wait for cluster deletion.")
-    parser.add_argument('--region', help='Region.')
+    parser.add_argument('--region', help='Region.', required=True)
     parser.add_argument('--dry-run', action='store_true',
                         help="Print gcloud dataproc command, but don't run it.")
 

--- a/hail/python/hailtop/hailctl/dataproc/submit.py
+++ b/hail/python/hailtop/hailctl/dataproc/submit.py
@@ -12,6 +12,7 @@ def init_parser(parser):
     parser.add_argument('--pyfiles', required=False, type=str, help='Comma-separated list of files (or directories with python files) to add to the PYTHONPATH.')
     parser.add_argument('--properties', '-p', required=False, type=str, help='Extra Spark properties to set.')
     parser.add_argument('--gcloud_configuration', help='Google Cloud configuration to submit job (defaults to currently set configuration).')
+    parser.add_argument('--region', help='Region.')
     parser.add_argument('--dry-run', action='store_true', help="Print gcloud dataproc command, but don't run it.")
 
 
@@ -39,7 +40,8 @@ def main(args, pass_through_args):  # pylint: disable=unused-argument
         '--cluster={}'.format(args.name),
         '--files={}'.format(files),
         '--py-files={}'.format(pyfiles),
-        '--properties={}'.format(properties)
+        '--properties={}'.format(properties),
+        '--region={}'.format(args.region)
     ]
     if args.gcloud_configuration:
         cmd.append('--configuration={}'.format(args.gcloud_configuration))

--- a/hail/python/hailtop/hailctl/dataproc/submit.py
+++ b/hail/python/hailtop/hailctl/dataproc/submit.py
@@ -29,7 +29,7 @@ def main(args, pass_through_args):  # pylint: disable=unused-argument
         pyfiles = args.pyfiles
     else:
         pyfiles = []
-        elif args.pyfiles:
+        if args.pyfiles:
             pyfiles.extend(args.pyfiles.split(','))
         pyfiles.extend(os.environ.get('HAIL_SCRIPTS', '').split(':'))
         if pyfiles:

--- a/hail/python/hailtop/hailctl/dataproc/submit.py
+++ b/hail/python/hailtop/hailctl/dataproc/submit.py
@@ -12,7 +12,7 @@ def init_parser(parser):
     parser.add_argument('--pyfiles', required=False, type=str, help='Comma-separated list of files (or directories with python files) to add to the PYTHONPATH.')
     parser.add_argument('--properties', '-p', required=False, type=str, help='Extra Spark properties to set.')
     parser.add_argument('--gcloud_configuration', help='Google Cloud configuration to submit job (defaults to currently set configuration).')
-    parser.add_argument('--region', help='Region.')
+    parser.add_argument('--region', help='Region.', required=True)
     parser.add_argument('--dry-run', action='store_true', help="Print gcloud dataproc command, but don't run it.")
 
 

--- a/hail/python/hailtop/hailctl/dataproc/submit.py
+++ b/hail/python/hailtop/hailctl/dataproc/submit.py
@@ -22,27 +22,7 @@ def main(args, pass_through_args):  # pylint: disable=unused-argument
     files = ''
     if args.files:
         files = args.files
-    pyfiles = []
-    if args.pyfiles:
-        pyfiles.extend(args.pyfiles.split(','))
-    pyfiles.extend(os.environ.get('HAIL_SCRIPTS', '').split(':'))
-    if pyfiles:
-        tfile = tempfile.mkstemp(suffix='.zip', prefix='pyscripts_')[1]
-        zipf = zipfile.ZipFile(tfile, 'w', zipfile.ZIP_DEFLATED)
-        for hail_script_entry in pyfiles:
-            if hail_script_entry.endswith('.py'):
-                zipf.write(hail_script_entry, arcname=os.path.basename(hail_script_entry))
-            else:
-                for root, _, pyfiles_walk in os.walk(hail_script_entry):
-                    for pyfile in pyfiles_walk:
-                        if pyfile.endswith('.py'):
-                            zipf.write(os.path.join(root, pyfile),
-                                       os.path.relpath(os.path.join(root, pyfile),
-                                                       os.path.join(hail_script_entry, '..')))
-        zipf.close()
-        pyfiles = tfile
-    else:
-        pyfiles = ''
+    pyfiles = args.pyfiles
 
     # create properties argument
     properties = ''

--- a/hail/python/hailtop/hailctl/dataproc/submit.py
+++ b/hail/python/hailtop/hailctl/dataproc/submit.py
@@ -24,6 +24,7 @@ def main(args, pass_through_args):  # pylint: disable=unused-argument
     if args.files:
         files = args.files
 
+    # If you only provide one (comma-sep) argument, and it's a zip file, use that file directly
     if args.pyfiles and args.pyfiles.endswith('.zip') and not ',' in args.pyfiles:
         # Adding the zip archive directly
         pyfiles = args.pyfiles

--- a/hail/python/hailtop/hailctl/dataproc/submit.py
+++ b/hail/python/hailtop/hailctl/dataproc/submit.py
@@ -23,7 +23,32 @@ def main(args, pass_through_args):  # pylint: disable=unused-argument
     files = ''
     if args.files:
         files = args.files
-    pyfiles = args.pyfiles
+
+    if args.pyfiles and args.pyfiles.endswith('.zip') and not ',' in args.pyfiles:
+        # Adding the zip archive directly
+        pyfiles = args.pyfiles
+    else:
+        pyfiles = []
+        elif args.pyfiles:
+            pyfiles.extend(args.pyfiles.split(','))
+        pyfiles.extend(os.environ.get('HAIL_SCRIPTS', '').split(':'))
+        if pyfiles:
+            tfile = tempfile.mkstemp(suffix='.zip', prefix='pyscripts_')[1]
+            zipf = zipfile.ZipFile(tfile, 'w', zipfile.ZIP_DEFLATED)
+            for hail_script_entry in pyfiles:
+                if hail_script_entry.endswith('.py'):
+                    zipf.write(hail_script_entry, arcname=os.path.basename(hail_script_entry))
+                else:
+                    for root, _, pyfiles_walk in os.walk(hail_script_entry):
+                        for pyfile in pyfiles_walk:
+                            if pyfile.endswith('.py'):
+                                zipf.write(os.path.join(root, pyfile),
+                                           os.path.relpath(os.path.join(root, pyfile),
+                                                           os.path.join(hail_script_entry, '..')))
+            zipf.close()
+            pyfiles = tfile
+        else:
+            pyfiles = ''
 
     # create properties argument
     properties = ''


### PR DESCRIPTION
A few adjustments to `hailctl dataproc` relevant mostly for us for the time we are using dataproc (allowing a zip archive as pyfiles, and add the `--region` option). Examples in the joint-calling workflow [README](https://github.com/populationgenomics/joint-calling-workflow) rely on these changes.