### PR TITLE
prod_deploy: make sure revision is consistent

### DIFF
--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - name: "deploy"
         run: |
-          curl --fail -X POST -H "Authorization: Bearer ${{ secrets.CI_TOKEN }}" -H "Content-Type:application/json" -d '{"steps": ["deploy_auth", "deploy_batch", "deploy_ci", "deploy_notebook", "deploy_query", "deploy_router"]}' https://ci.hail.populationgenomics.org.au/api/v1alpha/prod_deploy
+          curl --fail -X POST -H "Authorization: Bearer ${{ secrets.CI_TOKEN }}" -H "Content-Type:application/json" -d '{"steps": ["deploy_auth", "deploy_batch", "deploy_ci", "deploy_notebook", "deploy_query", "deploy_router"], "sha": "${{ github.sha }}"}' https://ci.hail.populationgenomics.org.au/api/v1alpha/prod_deploy

--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - name: "deploy"
         run: |
-          curl --fail -X POST -H "Authorization: Bearer ${{ secrets.CI_TOKEN }}" -H "Content-Type:application/json" -d '{"steps": ["deploy_auth", "deploy_batch", "deploy_ci", "deploy_notebook", "deploy_query", "deploy_router"], "sha": "${{ github.sha }}"}' https://ci.hail.populationgenomics.org.au/api/v1alpha/prod_deploy
+          curl --fail -X POST -H "Authorization: Bearer ${{ secrets.CI_TOKEN }}" -H "Content-Type:application/json" -d '{"steps": ["deploy_auth", "deploy_batch", "deploy_ci", "deploy_notebook", "deploy_query", "deploy_router"], "expected_sha": "${{ github.sha }}"}' https://ci.hail.populationgenomics.org.au/api/v1alpha/prod_deploy

--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - name: "deploy"
         run: |
-          curl --fail -X POST -H "Authorization: Bearer ${{ secrets.CI_TOKEN }}" -H "Content-Type:application/json" -d '{"steps": ["deploy_auth", "deploy_batch", "deploy_ci", "deploy_notebook", "deploy_query", "deploy_router"], "expected_sha": "${{ github.sha }}"}' https://ci.hail.populationgenomics.org.au/api/v1alpha/prod_deploy
+          curl --fail -X POST -H "Authorization: Bearer ${{ secrets.CI_TOKEN }}" -H "Content-Type:application/json" -d '{"steps": ["deploy_auth", "deploy_batch", "deploy_ci", "deploy_notebook", "deploy_query", "deploy_router"], "sha": "${{ github.sha }}"}' https://ci.hail.populationgenomics.org.au/api/v1alpha/prod_deploy

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -152,8 +152,14 @@ async def prod_deploy(request, userdata):
     watched_branch = WatchedBranch(
         0, FQBranch.from_short_str('populationgenomics/hail:main'), True
     )
+    # We only allow to deploy to prod from the HEAD revision; however we are using
+    # the sha parameter to verify that HEAD points to what we expect
     watched_branch.sha = 'HEAD'
-    await watched_branch._start_deploy(app['batch_client'], steps)
+    await watched_branch._start_deploy(
+        app['batch_client'],
+        steps,
+        sha_must_be=params.get('sha'),
+    )
 
     batch = watched_branch.deploy_batch
     if not isinstance(batch, MergeFailureBatch):

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -152,14 +152,11 @@ async def prod_deploy(request, userdata):
     watched_branch = WatchedBranch(
         0, FQBranch.from_short_str('populationgenomics/hail:main'), True
     )
-    # We only allow to deploy to prod from the HEAD revision; however we are using
-    # the sha parameter to verify that HEAD points to what we expect
-    watched_branch.sha = 'HEAD'
-    await watched_branch._start_deploy(
-        app['batch_client'],
-        steps,
-        expected_sha=params.get('expected_sha'),
-    )
+    if params.get('sha'):
+        watched_branch.sha = params['sha']
+    else:
+        watched_branch.sha = 'HEAD'
+    await watched_branch._start_deploy(app['batch_client'], steps)
 
     batch = watched_branch.deploy_batch
     if not isinstance(batch, MergeFailureBatch):

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -158,7 +158,7 @@ async def prod_deploy(request, userdata):
     await watched_branch._start_deploy(
         app['batch_client'],
         steps,
-        sha_must_be=params.get('sha'),
+        expected_sha=params.get('expected_sha'),
     )
 
     batch = watched_branch.deploy_batch

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -9,8 +9,7 @@ import gidgethub
 
 from hailtop.config import get_deploy_config
 from hailtop.batch_client.aioclient import Batch
-from hailtop.utils import check_shell, check_shell_output, RETRY_FUNCTION_SCRIPT, \
-    sync_check_shell_output
+from hailtop.utils import check_shell, check_shell_output, RETRY_FUNCTION_SCRIPT
 from .constants import GITHUB_CLONE_URL, AUTHORIZED_USERS, GITHUB_STATUS_CONTEXT
 from .build import BuildConfiguration, Code
 from .globals import is_test_deployment

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -788,7 +788,7 @@ mkdir -p {shq(repo_dir)}
                     log.exception(msg)
                     raise ValueError(msg)
 
-            with open(f'{shq(repo_dir)}/build.yaml', 'r') as f:
+            with open(f'{repo_dir}/build.yaml', 'r') as f:
                 config = BuildConfiguration(self, f.read(), scope='deploy', requested_step_names=steps)
 
             log.info(f'creating deploy batch for {self.branch.short_str()}')

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -761,7 +761,7 @@ url: {url}
                 log.info(f'cancel batch {batch.id} for {attrs["pr"]} {attrs["source_sha"]} => {attrs["target_sha"]}')
                 await batch.cancel()
 
-    async def _start_deploy(self, batch_client, steps=(), sha_must_be=None):
+    async def _start_deploy(self, batch_client, steps=(), expected_sha=None):
         # not deploying
         assert not self.deploy_batch or self.deploy_state
 
@@ -777,11 +777,18 @@ mkdir -p {shq(repo_dir)}
 (cd {shq(repo_dir)}; {self.checkout_script()})
 '''
             )
-            if sha_must_be:
-                out, err = sync_check_shell_output(f'(cd {repo_dir}; git rev-parse {self.sha})')
+            if expected_sha is not None:
+                out, err = sync_check_shell_output(f'(cd {shq(repo_dir)}; git rev-parse {self.sha})')
                 current_sha = out.decode().strip()
-                assert current_sha == sha_must_be, (current_sha, sha_must_be)
-            with open(f'{repo_dir}/build.yaml', 'r') as f:
+                if current_sha != expected_sha:
+                    msg = (
+                        f'SHA of the cloned repository {current_sha} does not match'
+                        f'the expected SHA {expected_sha}'
+                    )
+                    log.exception(msg)
+                    raise ValueError(msg)
+
+            with open(f'{shq(repo_dir)}/build.yaml', 'r') as f:
                 config = BuildConfiguration(self, f.read(), scope='deploy', requested_step_names=steps)
 
             log.info(f'creating deploy batch for {self.branch.short_str()}')

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -781,8 +781,9 @@ mkdir -p {shq(repo_dir)}
             # To make sure that the revision is consistent during the entire build,
             # we are replacing HEAD with the actual SHA of the revision.
             if self.sha == 'HEAD':
-                self.sha = sync_check_shell_output(
+                out, err = sync_check_shell_output(
                     f'(cd {shq(repo_dir)}; git rev-parse {self.sha})')
+                self.sha = out.decode().strip()
 
             with open(f'{repo_dir}/build.yaml', 'r') as f:
                 config = BuildConfiguration(self, f.read(), scope='deploy', requested_step_names=steps)

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -761,7 +761,7 @@ url: {url}
                 log.info(f'cancel batch {batch.id} for {attrs["pr"]} {attrs["source_sha"]} => {attrs["target_sha"]}')
                 await batch.cancel()
 
-    async def _start_deploy(self, batch_client, steps=(), expected_sha=None):
+    async def _start_deploy(self, batch_client, steps=()):
         # not deploying
         assert not self.deploy_batch or self.deploy_state
 
@@ -777,16 +777,12 @@ mkdir -p {shq(repo_dir)}
 (cd {shq(repo_dir)}; {self.checkout_script()})
 '''
             )
-            if expected_sha is not None:
-                out, err = sync_check_shell_output(f'(cd {shq(repo_dir)}; git rev-parse {self.sha})')
-                current_sha = out.decode().strip()
-                if current_sha != expected_sha:
-                    msg = (
-                        f'SHA of the cloned repository {current_sha} does not match'
-                        f'the expected SHA {expected_sha}'
-                    )
-                    log.exception(msg)
-                    raise ValueError(msg)
+            # The repository is cloned multiple times during the build process.
+            # To make sure that the revision is consistent during the entire build,
+            # we are replacing HEAD with the actual SHA of the revision.
+            if self.sha == 'HEAD':
+                self.sha = sync_check_shell_output(
+                    f'(cd {shq(repo_dir)}; git rev-parse {self.sha})')
 
             with open(f'{repo_dir}/build.yaml', 'r') as f:
                 config = BuildConfiguration(self, f.read(), scope='deploy', requested_step_names=steps)

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -777,14 +777,6 @@ mkdir -p {shq(repo_dir)}
 (cd {shq(repo_dir)}; {self.checkout_script()})
 '''
             )
-            # The repository is cloned multiple times during the build process.
-            # To make sure that the revision is consistent during the entire build,
-            # we are replacing HEAD with the actual SHA of the revision.
-            if self.sha == 'HEAD':
-                out, err = sync_check_shell_output(
-                    f'(cd {shq(repo_dir)}; git rev-parse {self.sha})')
-                self.sha = out.decode().strip()
-
             with open(f'{repo_dir}/build.yaml', 'r') as f:
                 config = BuildConfiguration(self, f.read(), scope='deploy', requested_step_names=steps)
 


### PR DESCRIPTION
Making sure that the HEAD of the cloned repository points to the same revision as the one that triggered the GitHub workflow build.