### PR TITLE
Don't depend on create_ci_test_repo step in deploy_ci

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2856,7 +2856,6 @@ steps:
     - ci_database
     - deploy_auth
     - deploy_batch
-    - create_ci_test_repo
     - deploy_ci_agent
     - create_certs
  - kind: runImage

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -42,13 +42,8 @@ spec:
           env:
            - name: HAIL_DEPLOY_CONFIG_FILE
              value: /deploy-config/deploy-config.json
-{% if deploy %}
            - name: HAIL_WATCHED_BRANCHES
              value: '[]'
-{% else %}
-           - name: HAIL_WATCHED_BRANCHES
-             value: '[["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true]]'
-{% endif %}
            - name: HAIL_GCP_PROJECT
              value: "{{ global.project }}"
            - name: HAIL_GCP_ZONE


### PR DESCRIPTION
Otherwise `deploy_ci` fails in the CPG setting.