### PR TITLE
Conda: pyspark3; make sure gsutil is available on build stage

### DIFF
--- a/conda/hail/meta-template.yaml
+++ b/conda/hail/meta-template.yaml
@@ -15,7 +15,7 @@ requirements:
     - rsync
   host:
     - python
-    - pyspark >=2.4,<2.4.2
+    - pyspark >=3.1.1,<3.2.0
     - openjdk 8.*
     - lz4
     - pytest-runner
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - openjdk 8.*
-    - pyspark >=2.4,<2.4.2
+    - pyspark >=3.1.1,<3.2.0
     - aiohttp
     - aiohttp-session
     - bokeh >1.3,<2.0

--- a/conda/hail/meta-template.yaml
+++ b/conda/hail/meta-template.yaml
@@ -20,6 +20,8 @@ requirements:
     - lz4
     - pytest-runner
     - pip
+    - google-cloud-sdk
+    - google-cloud-storage
   run:
     - python
     - openjdk 8.*


### PR DESCRIPTION
Addressing pyspark3 [support commit upstream](https://github.com/hail-is/hail/commit/a5304d8ef98bebb0185806864aed2178bc7cea0a#diff-2dc1edc4d4ac5d0c8b26720b9b4f10624af66a060087ed6049a69b2b47bb560b).

1. Update pyspark pins in the conda recipe
2. Adding gcloud into the build-time conda environment to address [an error](https://github.com/populationgenomics/hail/runs/2179791000) `make: gsutil: No such file or directory` caused by the new rule `elasticsearchJar` in the Makefile.

Only tested the build locally, so might have missed something else that would break the CI, will make follow up PRs if there is more.