### PR TITLE
Remove www subdomain

### DIFF
--- a/letsencrypt/subdomains.txt
+++ b/letsencrypt/subdomains.txt
@@ -1,6 +1,5 @@
 ci
 notebook
-www
 batch
 batch-driver
 benchmark


### PR DESCRIPTION
CPG doesn't run a www server for Hail. With this subdomain enabled, we get a resolution error in the gateway for `www.default.svc.cluster.local`.