### PR TITLE
Add Bloop to Gradle build config

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -3,6 +3,10 @@ buildscript {
         mavenCentral()
         jcenter()
     }
+
+    dependencies {
+        classpath 'ch.epfl.scala:gradle-bloop_2.12:1.4.8'
+    }
 }
 
 plugins {
@@ -349,4 +353,8 @@ task shadowTestJar(type: ShadowJar) {
     classifier = 'spark-test'
     from project.sourceSets.main.output, project.sourceSets.test.output
     configurations = [project.configurations.hailTestJar]
+}
+
+allprojects {
+    apply plugin: 'bloop'
 }


### PR DESCRIPTION
This allows Scala Metals to work properly in VS Code.

Further instructions are contained in https://github.com/populationgenomics/team-docs/pull/86.