### PR TITLE
bootstrap render_config_mk: add missing vars from global-config

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,11 +1,14 @@
-DOCKER_PREFIX := australia-southeast1-docker.pkg.dev/hail-295901/hail
-INTERNAL_IP := 10.152.0.10
-IP := 35.201.29.236
-DOMAIN := hail.populationgenomics.org.au
 CLOUD := gcp
+DOCKER_PREFIX := australia-southeast1-docker.pkg.dev/hail-295901/hail
+DOCKER_ROOT_IMAGE := australia-southeast1-docker.pkg.dev/hail-295901/hail/ubuntu:20.04
+DOMAIN := hail.populationgenomics.org.au
 PROJECT := hail-295901
 REGION := australia-southeast1
 ZONE := australia-southeast1-b
+HAIL_TEST_GCS_BUCKET := hail-test-0d3f214ff5
+INTERNAL_IP := 10.152.0.10
+IP := 35.201.29.236
+KUBERNETES_SERVER_URL := https://34.87.199.41
 
 ifeq ($(NAMESPACE),default)
 SCOPE = deploy

--- a/infra/bootstrap_utils.sh
+++ b/infra/bootstrap_utils.sh
@@ -8,25 +8,29 @@ fi
 source $HAIL/devbin/functions.sh
 
 render_config_mk() {
+    CLOUD=$(get_global_config_field cloud)
     DOCKER_PREFIX=$(get_global_config_field docker_prefix)
     DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image)
-    INTERNAL_IP=$(get_global_config_field internal_ip)
-    IP=$(get_global_config_field ip)
     DOMAIN=$(get_global_config_field domain)
-    CLOUD=$(get_global_config_field cloud)
     PROJECT=$(get_global_config_field gcp_project)
     REGION=$(get_global_config_field gcp_region)
     ZONE=$(get_global_config_field gcp_zone)
+    HAIL_TEST_GCS_BUCKET=$(get_global_config_field hail_test_gcs_bucket)
+    INTERNAL_IP=$(get_global_config_field internal_ip)
+    IP=$(get_global_config_field ip)
+    KUBERNETES_SERVER_URL=$(get_global_config_field kubernetes_server_url)
     cat >$HAIL/config.mk <<EOF
+CLOUD := $CLOUD
 DOCKER_PREFIX := $DOCKER_PREFIX
 DOCKER_ROOT_IMAGE := $DOCKER_ROOT_IMAGE
-INTERNAL_IP := $INTERNAL_IP
-IP := $IP
 DOMAIN := $DOMAIN
-CLOUD := $CLOUD
 PROJECT := $PROJECT
 REGION := $REGION
 ZONE := $ZONE
+HAIL_TEST_GCS_BUCKET := $HAIL_TEST_GCS_BUCKET
+INTERNAL_IP := $INTERNAL_IP
+IP := $IP
+KUBERNETES_SERVER_URL := $KUBERNETES_SERVER_URL
 
 ifeq (\$(NAMESPACE),default)
 SCOPE = deploy

--- a/infra/bootstrap_utils.sh
+++ b/infra/bootstrap_utils.sh
@@ -9,6 +9,7 @@ source $HAIL/devbin/functions.sh
 
 render_config_mk() {
     DOCKER_PREFIX=$(get_global_config_field docker_prefix)
+    DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image)
     INTERNAL_IP=$(get_global_config_field internal_ip)
     IP=$(get_global_config_field ip)
     DOMAIN=$(get_global_config_field domain)
@@ -18,6 +19,7 @@ render_config_mk() {
     ZONE=$(get_global_config_field gcp_zone)
     cat >$HAIL/config.mk <<EOF
 DOCKER_PREFIX := $DOCKER_PREFIX
+DOCKER_ROOT_IMAGE := $DOCKER_ROOT_IMAGE
 INTERNAL_IP := $INTERNAL_IP
 IP := $IP
 DOMAIN := $DOMAIN


### PR DESCRIPTION
Squash-merge!

Few more variables are expected to be in config.mk for manual bootstrap:
* DOCKER_ROOT_IMAGE used to build `batch` workers and `benchmark`
* HAIL_TEST_GCS_BUCKET used to build `query`
* KUBERNETES_SERVER_URL used to build `amundsen`

(Also reordered declarations to reflect the order in global-config)