### PR TITLE
Mount github-oauth-token from ci-config

### DIFF
--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -102,6 +102,9 @@ spec:
            - mountPath: /sql-config
              name: sql-config
              readOnly: true
+           - mountPath: /secrets/oauth-token
+             name: hail-ci-0-1-github-oauth-token
+             readOnly: true
            - mountPath: /user-tokens
              name: ci-tokens
              readOnly: true

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -136,6 +136,9 @@ spec:
          secret:
            optional: false
            secretName: "{{ ci_database.user_secret_name }}"
+       - name: hail-ci-0-1-github-oauth-token
+         secret:
+           secretName: hail-ci-0-1-github-oauth-token
        - name: ci-tokens
          secret:
            secretName: ci-tokens


### PR DESCRIPTION
Enables CI with watched branches.