### PR TITLE
GitHub workflow: add "deploy" step

### DIFF
--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -12,7 +12,7 @@ jobs:
           DEPLOY_BATCH_URL=$(curl --fail --silent --show-error -X POST \
               -H "Authorization: Bearer ${{ secrets.CI_TOKEN }}" \
               -H "Content-Type:application/json" \
-              -d '{"steps": ["deploy_auth", "deploy_batch", "deploy_ci", "deploy_memory", "deploy_notebook", "upload_query_jar"], "sha": "${{ github.sha }}"}' \
+              -d '{"steps": ["deploy_auth", "deploy_batch", "deploy_ci", "deploy_memory", "deploy_notebook", "upload_query_jar", "deploy"], "sha": "${{ github.sha }}"}' \
               https://ci.hail.populationgenomics.org.au/api/v1alpha/prod_deploy)
           echo DEPLOY_BATCH_URL=$DEPLOY_BATCH_URL >> $GITHUB_ENV
 


### PR DESCRIPTION
We need to add `deploy` step to CI too to make sure `hailgenetics_hail_image` is built.