### PR TITLE
Pass GitHub SHA to analysis-runner redeploy workflow

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -64,4 +64,4 @@ jobs:
             -H "Authorization: token ${{ secrets.ANALYSIS_SERVER_GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/populationgenomics/analysis-runner/actions/workflows/6364059/dispatches \
-            -d '{"ref": "main", "inputs": {"hail_version": "'$version'"}}'
+            -d '{"ref": "main", "inputs": {"hail_version": "'$version'", "hail_sha": "${{ github.sha }}"}}'


### PR DESCRIPTION
To enable setting `HAIL_SHA` automatically in the analysis-runner.

Context: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1646979994175289?thread_ts=1646887215.452969&cid=C018KFBCR1C