### PR TITLE
Add build.yaml step to upload hail wheel in prod_deploy

### DIFF
--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -12,7 +12,7 @@ jobs:
           DEPLOY_BATCH_URL=$(curl --fail --silent --show-error -X POST \
               -H "Authorization: Bearer ${{ secrets.CI_TOKEN }}" \
               -H "Content-Type:application/json" \
-              -d '{"steps": ["deploy_auth", "deploy_batch", "deploy_ci", "deploy_hailgenetics_image", "deploy_memory", "upload_query_jar"], "sha": "${{ github.sha }}"}' \
+              -d '{"steps": ["deploy_auth", "deploy_batch", "deploy_ci", "deploy_hailgenetics_image", "deploy_memory", "upload_query_jar", "deploy_wheel"], "sha": "${{ github.sha }}"}' \
               https://ci.hail.populationgenomics.org.au/api/v1alpha/prod_deploy)
           echo DEPLOY_BATCH_URL=$DEPLOY_BATCH_URL >> $GITHUB_ENV
 

--- a/build.yaml
+++ b/build.yaml
@@ -4809,6 +4809,31 @@ steps:
     clouds:
       - gcp
   - kind: runImage
+    name: deploy_wheel
+    image:
+      valueFrom: hail_pip_installed_image.image
+    script: |
+      set -ex
+      tar xvf /io/wheel-container.tar
+      gcloud auth activate-service-account --key-file=/gsa-key/key.json
+      HAIL_WHEEL_URL=gs://cpg-hail-ci/wheels/hail-$(cat /io/hail_pip_version)-py3-none-any.whl
+      python3 -m hailtop.aiotools.copy 'null' '[
+      {"from": "hail-*-py3-none-any.whl", "to": "'${HAIL_WHEEL_URL}'"}]'
+    inputs:
+      - from: /hail_pip_version
+        to: /io/hail_pip_version
+      - from: /just-wheel/wheel-container.tar
+        to: /io/wheel-container.tar
+    scopes:
+      - deploy
+      - dev
+    dependsOn:
+      - default_ns
+      - hail_pip_installed_image
+      - build_hail_jar_and_wheel_only
+    clouds:
+      - gcp
+  - kind: runImage
     name: deploy_hailgenetics_image
     image:
       valueFrom: ci_utils_image.image


### PR DESCRIPTION
Uploading into `gs://cpg-hail-ci/wheels`, not sure if we should have a separate bucket for wheels/

And thinking if we should instead adopt the upstream `deploy` step for for tagging the genetics image and uploading a wheel, after all.