### PR TITLE
Revert "Try highmem JVM Query jobs again (#160)"

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -762,7 +762,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 if spec['process']['type'] == 'jvm':
                     if 'cpu' in resources:
                         raise web.HTTPBadRequest(reason='jvm jobs may not specify cpu')
-                    if 'memory' in resources and resources['memory'] != 'highmem':
+                    if 'memory' in resources and resources['memory'] != 'standard':
                         raise web.HTTPBadRequest(reason='jvm jobs may not specify memory')
                     if 'storage' in resources:
                         raise web.HTTPBadRequest(reason='jvm jobs may not specify storage')

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1858,17 +1858,17 @@ class JVM:
     @classmethod
     async def create_process(cls, socket_file: str) -> BufferedOutputProcess:
         # JVM and Hail both treat MB as 1024 * 1024 bytes.
-        # JVMs only start in highmem workers which have 6.5 GiB == 6656 MiB per core.
-        # We only allocate 6500 MiB so that we stay well below the machine's max memory.
-        # We allocate 60% of memory per core to off heap memory: 2600 + 3900 = 6500.
+        # JVMs only start in standard workers which have 3.75 GiB == 3840 MiB per core.
+        # We only allocate 3700 MiB so that we stay well below the machine's max memory.
+        # We allocate 60% of memory per core to off heap memory: 1480 + 2220 = 3700.
         return await BufferedOutputProcess.create(
             'java',
-            '-Xmx2600M',
+            '-Xmx1480M',
             '-cp',
             f'/jvm-entryway:/jvm-entryway/junixsocket-selftest-2.3.3-jar-with-dependencies.jar:{JVM.SPARK_HOME}/jars/*',
             'is.hail.JVMEntryway',
             socket_file,
-            env={'HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB': '3900'},
+            env={'HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB': '2220'},
         )
 
     @classmethod
@@ -2066,19 +2066,19 @@ class Worker:
         self._jvms: List[JVM] = []
 
     async def _initialize_jvms(self):
-        if instance_config.worker_type() in ('highmem', 'D'):
+        if instance_config.worker_type() in ('standard', 'D'):
             self._jvms = await asyncio.gather(*[JVM.create(i) for i in range(CORES)])
         log.info(f'JVMs initialized {self._jvms}')
 
     async def borrow_jvm(self) -> JVM:
-        if instance_config.worker_type() not in ('highmem', 'D'):
+        if instance_config.worker_type() not in ('standard', 'D'):
             raise ValueError(f'JVM jobs not allowed on {instance_config.worker_type()}')
         await asyncio.shield(self._jvm_initializer_task)
         assert self._jvms
         return self._jvms.pop()
 
     def return_jvm(self, jvm: JVM):
-        if instance_config.worker_type() not in ('highmem', 'D'):
+        if instance_config.worker_type() not in ('standard', 'D'):
             raise ValueError(f'JVM jobs not allowed on {instance_config.worker_type()}')
         jvm.reset()
         self._jvms.append(jvm)

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -214,7 +214,7 @@ class ServiceBackend(Backend):
                     batch_attributes['name'],
                     iodir + '/in',
                     iodir + '/out',
-                ], mount_tokens=True, resources={'preemptible': False, 'memory': 'highmem'})
+                ], mount_tokens=True, resources={'preemptible': False, 'memory': 'standard'})
                 b = await bb.submit(disable_progress_bar=self.disable_progress_bar)
 
             with timings.step("wait batch"):

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -164,9 +164,7 @@ class ServiceBackend(
             JString(s"$i"))),
           "type" -> JString("jvm")),
         "mount_tokens" -> JBool(true),
-        "resources" -> JObject(
-          "preemptible" -> JBool(true),
-          "memory" -> JString("highmem"))
+        "resources" -> JObject("preemptible" -> JBool(true))
       )
       i += 1
     }


### PR DESCRIPTION
This reverts commit e8bb4790f0fa715cb210d2ac57bd781f990bf4b2.

The actual fix for the `to_pandas` OOM issues will consist of changing the temporary JSON encoding format to something more efficient.

Reverting this previous experiment should make it easier for us to perform future merges from upstream.