### PR TITLE
Add query-gsa-secret

### DIFF
--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -470,6 +470,12 @@ module "test_gsa_secret" {
   ]
 }
 
+module "query_gsa_secret" {
+  source = "./gsa_k8s_secret"
+  name = "query"
+  iam_roles = ["storage.admin"]
+}
+
 resource "google_storage_bucket_iam_member" "test_bucket_admin" {
   bucket = module.hail_test_gcs_bucket.name
   role = "roles/storage.admin"


### PR DESCRIPTION
The `upload_query_jar` CI step uses `query-gsa-key`, which is missing from infra:
https://github.com/populationgenomics/hail/blob/main/build.yaml#L3113-L3139

CI was failing because of that: https://ci.hail.populationgenomics.org.au/batches/30204/jobs/37