### PR TITLE
Increase https timeout from 5 to 20

### DIFF
--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -101,7 +101,7 @@ class ClientSession:
         assert 'connector' not in kwargs
 
         if timeout is None:
-            timeout = aiohttp.ClientTimeout(total=5)
+            timeout = aiohttp.ClientTimeout(total=20)
 
         self.raise_for_status = raise_for_status
         self.client_session = aiohttp.ClientSession(


### PR DESCRIPTION
To address tasks getting stuck on the upload stage.

Context:
* Slack thread: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1652243818817869 (and https://centrepopgen.slack.com/archives/C018KFBCR1C/p1652309451013589)
* Zulip thread: https://hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/Timeout.20error/near/281163629
* Dan's PR with proper fix: https://github.com/hail-is/hail/pull/11830 (WIP at the moment; but stealing the first part of it that would hopefully be to unblock us enough until the full fix is merged)