### PR TITLE
Allow to select a pool for a job through a label

### DIFF
--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -109,6 +109,7 @@ WHERE removed = 0 AND inst_coll = %s;
         self.data_disk_size_gb = config.data_disk_size_gb
         self.data_disk_size_standing_gb = config.data_disk_size_standing_gb
         self.preemptible = config.preemptible
+        self.label = config.label
 
     @property
     def local_ssd_data_disk(self) -> bool:
@@ -130,6 +131,7 @@ WHERE removed = 0 AND inst_coll = %s;
             'max_instances': self.max_instances,
             'max_live_instances': self.max_live_instances,
             'preemptible': self.preemptible,
+            'label': self.label,
         }
 
     def configure(self, pool_config: PoolConfig):
@@ -148,6 +150,7 @@ WHERE removed = 0 AND inst_coll = %s;
         self.max_instances = pool_config.max_instances
         self.max_live_instances = pool_config.max_live_instances
         self.preemptible = pool_config.preemptible
+        self.label = pool_config.label
 
     def adjust_for_remove_instance(self, instance):
         super().adjust_for_remove_instance(instance)

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -485,6 +485,8 @@ async def pool_config_update(request, userdata):  # pylint: disable=unused-argum
             session, 'Max live instances', post['max_live_instances'], lambda v: v > 0, 'a positive integer'
         )
 
+        label = post['label'] or None
+
         enable_standing_worker = 'enable_standing_worker' in post
 
         possible_worker_cores = []
@@ -537,7 +539,7 @@ async def pool_config_update(request, userdata):  # pylint: disable=unused-argum
             max_instances,
             max_live_instances,
             pool.preemptible,
-            pool.label,
+            label,
         )
         await pool_config.update_database(db)
         pool.configure(pool_config)

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -485,7 +485,7 @@ async def pool_config_update(request, userdata):  # pylint: disable=unused-argum
             session, 'Max live instances', post['max_live_instances'], lambda v: v > 0, 'a positive integer'
         )
 
-        label = post['label'] or None
+        label = post['label']
 
         enable_standing_worker = 'enable_standing_worker' in post
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -537,6 +537,7 @@ async def pool_config_update(request, userdata):  # pylint: disable=unused-argum
             max_instances,
             max_live_instances,
             pool.preemptible,
+            pool.label,
         )
         await pool_config.update_database(db)
         pool.configure(pool_config)

--- a/batch/batch/driver/templates/pool.html
+++ b/batch/batch/driver/templates/pool.html
@@ -31,6 +31,7 @@
     <div>Standing worker cores: <input name="standing_worker_cores" value="{{ pool.standing_worker_cores }}" /></div>
     <div>Max instances: <input name="max_instances" value="{{ pool.max_instances }}" /></div>
     <div>Max live instances: <input name="max_live_instances" value="{{ pool.max_live_instances }}" /></div>
+    <div>Label: <input name="label" value="{{ pool.label }}" /></div>
     <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
     <button>
       Update

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -886,7 +886,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 worker_type = None
                 machine_type = resources.get('machine_type')
-                pool_name_prefix = resources.get('pool_name_prefix')
+                pool_label = resources.get('pool_label')
                 preemptible = resources.get('preemptible', BATCH_JOB_DEFAULT_PREEMPTIBLE)
 
                 if machine_type and machine_type not in valid_machine_types(cloud):
@@ -895,8 +895,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 if machine_type and ('cpu' in resources or 'memory' in resources):
                     raise web.HTTPBadRequest(reason='cannot specify cpu and memory with machine_type')
 
-                if machine_type and pool_name_prefix:
-                    raise web.HTTPBadRequest(reason='cannot specify pool name with machine_type')
+                if machine_type and pool_label:
+                    raise web.HTTPBadRequest(reason='cannot specify pool label with machine_type')
 
                 if spec['process']['type'] == 'jvm':
                     jvm_requested_cpu = parse_cpu_in_mcpu(resources.get('cpu', BATCH_JOB_DEFAULT_CPU))
@@ -965,7 +965,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 inst_coll_configs: InstanceCollectionConfigs = app['inst_coll_configs']
 
                 result, exc = inst_coll_configs.select_inst_coll(
-                    cloud, machine_type, pool_name_prefix, preemptible, worker_type, req_cores_mcpu, req_memory_bytes, req_storage_bytes
+                    cloud, machine_type, pool_label, preemptible, worker_type, req_cores_mcpu, req_memory_bytes, req_storage_bytes
                 )
 
                 if exc:

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -886,7 +886,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 worker_type = None
                 machine_type = resources.get('machine_type')
-                pool_label = resources.get('pool_label')
+                pool_label = resources.get('pool_label') or ''
                 preemptible = resources.get('preemptible', BATCH_JOB_DEFAULT_PREEMPTIBLE)
 
                 if machine_type and machine_type not in valid_machine_types(cloud):

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -886,7 +886,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 worker_type = None
                 machine_type = resources.get('machine_type')
-                pool_name = resources.get('pool_name')
+                pool_name_prefix = resources.get('pool_name_prefix')
                 preemptible = resources.get('preemptible', BATCH_JOB_DEFAULT_PREEMPTIBLE)
 
                 if machine_type and machine_type not in valid_machine_types(cloud):
@@ -895,7 +895,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 if machine_type and ('cpu' in resources or 'memory' in resources):
                     raise web.HTTPBadRequest(reason='cannot specify cpu and memory with machine_type')
 
-                if machine_type and pool_name:
+                if machine_type and pool_name_prefix:
                     raise web.HTTPBadRequest(reason='cannot specify pool name with machine_type')
 
                 if spec['process']['type'] == 'jvm':
@@ -965,7 +965,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 inst_coll_configs: InstanceCollectionConfigs = app['inst_coll_configs']
 
                 result, exc = inst_coll_configs.select_inst_coll(
-                    cloud, machine_type, pool_name, preemptible, worker_type, req_cores_mcpu, req_memory_bytes, req_storage_bytes
+                    cloud, machine_type, pool_name_prefix, preemptible, worker_type, req_cores_mcpu, req_memory_bytes, req_storage_bytes
                 )
 
                 if exc:

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -886,6 +886,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 worker_type = None
                 machine_type = resources.get('machine_type')
+                pool_name = resources.get('pool_name')
                 preemptible = resources.get('preemptible', BATCH_JOB_DEFAULT_PREEMPTIBLE)
 
                 if machine_type and machine_type not in valid_machine_types(cloud):
@@ -893,6 +894,9 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 if machine_type and ('cpu' in resources or 'memory' in resources):
                     raise web.HTTPBadRequest(reason='cannot specify cpu and memory with machine_type')
+
+                if machine_type and pool_name:
+                    raise web.HTTPBadRequest(reason='cannot specify pool name with machine_type')
 
                 if spec['process']['type'] == 'jvm':
                     jvm_requested_cpu = parse_cpu_in_mcpu(resources.get('cpu', BATCH_JOB_DEFAULT_CPU))
@@ -961,7 +965,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 inst_coll_configs: InstanceCollectionConfigs = app['inst_coll_configs']
 
                 result, exc = inst_coll_configs.select_inst_coll(
-                    cloud, machine_type, preemptible, worker_type, req_cores_mcpu, req_memory_bytes, req_storage_bytes
+                    cloud, machine_type, pool_name, preemptible, worker_type, req_cores_mcpu, req_memory_bytes, req_storage_bytes
                 )
 
                 if exc:

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -86,7 +86,7 @@ job_validator = keyed(
                 'cpu': regex(CPU_REGEXPAT, CPU_REGEX),
                 'storage': regex(STORAGE_REGEXPAT, STORAGE_REGEX),
                 'machine_type': str_type,
-                'label': str_type,
+                'pool_label': str_type,
                 'preemptible': bool_type,
             }
         ),

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -86,6 +86,7 @@ job_validator = keyed(
                 'cpu': regex(CPU_REGEXPAT, CPU_REGEX),
                 'storage': regex(STORAGE_REGEXPAT, STORAGE_REGEX),
                 'machine_type': str_type,
+                'label': str_type,
                 'preemptible': bool_type,
             }
         ),

--- a/batch/batch/inst_coll_config.py
+++ b/batch/batch/inst_coll_config.py
@@ -273,13 +273,13 @@ LEFT JOIN pools ON inst_colls.name = pools.name;
         self.resource_rates = resource_rates
         self.product_versions.update(product_versions_data)
 
-    def select_pool_from_cost(self, cloud, pool_name, cores_mcpu, memory_bytes, storage_bytes, preemptible):
+    def select_pool_from_cost(self, cloud, pool_name_prefix, cores_mcpu, memory_bytes, storage_bytes, preemptible):
         assert self.resource_rates is not None
 
         optimal_result = None
         optimal_cost = None
         for pool in self.name_pool_config.values():
-            if pool_name and pool.name != pool_name:
+            if pool_name_prefix and not pool.name.startswith(pool_name_prefix):
                 continue
 
             if pool.cloud != cloud or pool.preemptible != preemptible:
@@ -307,9 +307,9 @@ LEFT JOIN pools ON inst_colls.name = pools.name;
                     optimal_result = (pool.name, maybe_cores_mcpu, maybe_memory_bytes, maybe_storage_gib)
         return optimal_result
 
-    def select_pool_from_worker_type(self, cloud, pool_name, worker_type, cores_mcpu, memory_bytes, storage_bytes, preemptible):
+    def select_pool_from_worker_type(self, cloud, pool_name_prefix, worker_type, cores_mcpu, memory_bytes, storage_bytes, preemptible):
         for pool in self.name_pool_config.values():
-            if pool_name and pool.name != pool_name:
+            if pool_name_prefix and not pool.name.startswith(pool_name_prefix):
                 continue
             if pool.cloud == cloud and pool.worker_type == worker_type and pool.preemptible == preemptible:
                 result = pool.convert_requests_to_resources(cores_mcpu, memory_bytes, storage_bytes)
@@ -324,12 +324,12 @@ LEFT JOIN pools ON inst_colls.name = pools.name;
         return self.jpim_config.convert_requests_to_resources(machine_type, storage_bytes)
 
     def select_inst_coll(
-        self, cloud, machine_type, pool_name, preemptible, worker_type, req_cores_mcpu, req_memory_bytes, req_storage_bytes
+        self, cloud, machine_type, pool_name_prefix, preemptible, worker_type, req_cores_mcpu, req_memory_bytes, req_storage_bytes
     ):
         if worker_type is not None and machine_type is None:
             result = self.select_pool_from_worker_type(
                 cloud=cloud,
-                pool_name=pool_name,
+                pool_name_prefix=pool_name_prefix,
                 worker_type=worker_type,
                 cores_mcpu=req_cores_mcpu,
                 memory_bytes=req_memory_bytes,
@@ -339,7 +339,7 @@ LEFT JOIN pools ON inst_colls.name = pools.name;
         elif worker_type is None and machine_type is None:
             result = self.select_pool_from_cost(
                 cloud=cloud,
-                pool_name=pool_name,
+                pool_name_prefix=pool_name_prefix,
                 cores_mcpu=req_cores_mcpu,
                 memory_bytes=req_memory_bytes,
                 storage_bytes=req_storage_bytes,

--- a/batch/batch/inst_coll_config.py
+++ b/batch/batch/inst_coll_config.py
@@ -141,7 +141,7 @@ WHERE pools.name = %s;
         self.max_instances = max_instances
         self.max_live_instances = max_live_instances
         self.preemptible = preemptible
-        self.label = None
+        self.label = label
 
     def instance_config(self, product_versions: ProductVersions, location: str) -> InstanceConfig:
         return instance_config_from_pool_config(self, product_versions, location)

--- a/batch/sql/add-pool-label.sql
+++ b/batch/sql/add-pool-label.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pools` ADD `label` VARCHAR(100);

--- a/batch/sql/add-pool-label.sql
+++ b/batch/sql/add-pool-label.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `pools` ADD `label` VARCHAR(100);
+ALTER TABLE `pools` ADD `label` VARCHAR(100) NOT NULL;

--- a/batch/sql/add-seqr-pools.sql
+++ b/batch/sql/add-seqr-pools.sql
@@ -1,3 +1,4 @@
+-- Adds dedicated pools for the seqr loading pipeline, with the 'seqr' pool label.
 
 INSERT INTO inst_colls (`name`, `is_pool`, `boot_disk_size_gb`, `max_instances`, `max_live_instances`, `cloud`)
 SELECT 'seqr-standard', 1, boot_disk_size_gb, max_instances, max_live_instances, cloud
@@ -16,27 +17,27 @@ WHERE name = 'highcpu';
 
 INSERT INTO pools (`name`, `worker_type`, `worker_cores`, `worker_local_ssd_data_disk`,
   `worker_external_ssd_data_disk_size_gb`, `enable_standing_worker`, `standing_worker_cores`,
-  `preemptible`)
+  `preemptible`, `label`)
 SELECT 'seqr-standard', worker_type, worker_cores, worker_local_ssd_data_disk,
   worker_external_ssd_data_disk_size_gb, FALSE, standing_worker_cores,
-  TRUE
+  TRUE, 'seqr'
 FROM pools
 WHERE name = 'standard';
 
 INSERT INTO pools (`name`, `worker_type`, `worker_cores`, `worker_local_ssd_data_disk`,
   `worker_external_ssd_data_disk_size_gb`, `enable_standing_worker`, `standing_worker_cores`,
-  `preemptible`)
+  `preemptible`, `label`)
 SELECT 'seqr-highmem', worker_type, worker_cores, worker_local_ssd_data_disk,
   worker_external_ssd_data_disk_size_gb, FALSE, standing_worker_cores,
-  TRUE
+  TRUE, 'seqr'
 FROM pools
 WHERE name = 'highmem';
 
 INSERT INTO pools (`name`, `worker_type`, `worker_cores`, `worker_local_ssd_data_disk`,
   `worker_external_ssd_data_disk_size_gb`, `enable_standing_worker`, `standing_worker_cores`,
-  `preemptible`)
+  `preemptible`, `label`)
 SELECT 'seqr-highcpu', worker_type, worker_cores, worker_local_ssd_data_disk,
   worker_external_ssd_data_disk_size_gb, FALSE, standing_worker_cores,
-  TRUE
+  TRUE, 'seqr'
 FROM pools
 WHERE name = 'highcpu';

--- a/batch/sql/add-seqr-pools.sql
+++ b/batch/sql/add-seqr-pools.sql
@@ -1,0 +1,42 @@
+
+INSERT INTO inst_colls (`name`, `is_pool`, `boot_disk_size_gb`, `max_instances`, `max_live_instances`, `cloud`)
+SELECT 'seqr-standard', 1, boot_disk_size_gb, max_instances, max_live_instances, cloud
+FROM inst_colls
+WHERE name = 'standard';
+
+INSERT INTO inst_colls (`name`, `is_pool`, `boot_disk_size_gb`, `max_instances`, `max_live_instances`, `cloud`)
+SELECT 'seqr-highmem', 1, boot_disk_size_gb, max_instances, max_live_instances, cloud
+FROM inst_colls
+WHERE name = 'highmem';
+
+INSERT INTO inst_colls (`name`, `is_pool`, `boot_disk_size_gb`, `max_instances`, `max_live_instances`, `cloud`)
+SELECT 'seqr-highcpu', 1, boot_disk_size_gb, max_instances, max_live_instances, cloud
+FROM inst_colls
+WHERE name = 'highcpu';
+
+INSERT INTO pools (`name`, `worker_type`, `worker_cores`, `worker_local_ssd_data_disk`,
+  `worker_external_ssd_data_disk_size_gb`, `enable_standing_worker`, `standing_worker_cores`,
+  `preemptible`)
+SELECT 'seqr-standard', worker_type, worker_cores, worker_local_ssd_data_disk,
+  worker_external_ssd_data_disk_size_gb, enable_standing_worker, standing_worker_cores,
+  TRUE
+FROM pools
+WHERE name = 'standard';
+
+INSERT INTO pools (`name`, `worker_type`, `worker_cores`, `worker_local_ssd_data_disk`,
+  `worker_external_ssd_data_disk_size_gb`, `enable_standing_worker`, `standing_worker_cores`,
+  `preemptible`)
+SELECT 'seqr-highmem', worker_type, worker_cores, worker_local_ssd_data_disk,
+  worker_external_ssd_data_disk_size_gb, enable_standing_worker, standing_worker_cores,
+  TRUE
+FROM pools
+WHERE name = 'highmem';
+
+INSERT INTO pools (`name`, `worker_type`, `worker_cores`, `worker_local_ssd_data_disk`,
+  `worker_external_ssd_data_disk_size_gb`, `enable_standing_worker`, `standing_worker_cores`,
+  `preemptible`)
+SELECT 'seqr-highcpu', worker_type, worker_cores, worker_local_ssd_data_disk,
+  worker_external_ssd_data_disk_size_gb, enable_standing_worker, standing_worker_cores,
+  TRUE
+FROM pools
+WHERE name = 'highcpu';

--- a/batch/sql/add-seqr-pools.sql
+++ b/batch/sql/add-seqr-pools.sql
@@ -18,7 +18,7 @@ INSERT INTO pools (`name`, `worker_type`, `worker_cores`, `worker_local_ssd_data
   `worker_external_ssd_data_disk_size_gb`, `enable_standing_worker`, `standing_worker_cores`,
   `preemptible`)
 SELECT 'seqr-standard', worker_type, worker_cores, worker_local_ssd_data_disk,
-  worker_external_ssd_data_disk_size_gb, enable_standing_worker, standing_worker_cores,
+  worker_external_ssd_data_disk_size_gb, FALSE, standing_worker_cores,
   TRUE
 FROM pools
 WHERE name = 'standard';
@@ -27,7 +27,7 @@ INSERT INTO pools (`name`, `worker_type`, `worker_cores`, `worker_local_ssd_data
   `worker_external_ssd_data_disk_size_gb`, `enable_standing_worker`, `standing_worker_cores`,
   `preemptible`)
 SELECT 'seqr-highmem', worker_type, worker_cores, worker_local_ssd_data_disk,
-  worker_external_ssd_data_disk_size_gb, enable_standing_worker, standing_worker_cores,
+  worker_external_ssd_data_disk_size_gb, FALSE, standing_worker_cores,
   TRUE
 FROM pools
 WHERE name = 'highmem';
@@ -36,7 +36,7 @@ INSERT INTO pools (`name`, `worker_type`, `worker_cores`, `worker_local_ssd_data
   `worker_external_ssd_data_disk_size_gb`, `enable_standing_worker`, `standing_worker_cores`,
   `preemptible`)
 SELECT 'seqr-highcpu', worker_type, worker_cores, worker_local_ssd_data_disk,
-  worker_external_ssd_data_disk_size_gb, enable_standing_worker, standing_worker_cores,
+  worker_external_ssd_data_disk_size_gb, FALSE, standing_worker_cores,
   TRUE
 FROM pools
 WHERE name = 'highcpu';

--- a/build.yaml
+++ b/build.yaml
@@ -2003,6 +2003,8 @@ steps:
         script: /io/sql/kill-mjc-deadlocks.sql
       - name: add-nonpreemptible-pools
         script: /io/sql/add-nonpreemptible-pools.sql
+      - name: add-pool-label
+        script: /io/sql/add-pool-label.sql
     inputs:
       - from: /repo/batch/sql
         to: /io/sql

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -657,6 +657,8 @@ class ServiceBackend(Backend[bc.Batch]):
                 resources['storage'] = job._storage
             if job._machine_type:
                 resources['machine_type'] = job._machine_type
+            if job._pool_name:
+                resources['pool_name'] = job._pool_name
             if job._preemptible is not None:
                 resources['preemptible'] = job._preemptible
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -657,8 +657,8 @@ class ServiceBackend(Backend[bc.Batch]):
                 resources['storage'] = job._storage
             if job._machine_type:
                 resources['machine_type'] = job._machine_type
-            if job._pool_name:
-                resources['pool_name'] = job._pool_name
+            if job._pool_name_prefix:
+                resources['pool_name_prefix'] = job._pool_name_prefix
             if job._preemptible is not None:
                 resources['preemptible'] = job._preemptible
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -657,8 +657,8 @@ class ServiceBackend(Backend[bc.Batch]):
                 resources['storage'] = job._storage
             if job._machine_type:
                 resources['machine_type'] = job._machine_type
-            if job._pool_name_prefix:
-                resources['pool_name_prefix'] = job._pool_name_prefix
+            if job._pool_label:
+                resources['pool_label'] = job._pool_label
             if job._preemptible is not None:
                 resources['preemptible'] = job._preemptible
 

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -79,7 +79,7 @@ class Job:
         self._always_run: bool = False
         self._preemptible: Optional[bool] = None
         self._machine_type: Optional[str] = None
-        self._pool_name_prefix: Optional[str] = None
+        self._pool_label: Optional[str] = None
         self._timeout: Optional[Union[int, float]] = None
         self._cloudfuse: List[Tuple[str, str, bool]] = []
         self._env: Dict[str, str] = {}

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -79,7 +79,7 @@ class Job:
         self._always_run: bool = False
         self._preemptible: Optional[bool] = None
         self._machine_type: Optional[str] = None
-        self._pool_name: Optional[str] = None
+        self._pool_name_prefix: Optional[str] = None
         self._timeout: Optional[Union[int, float]] = None
         self._cloudfuse: List[Tuple[str, str, bool]] = []
         self._env: Dict[str, str] = {}

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -79,6 +79,7 @@ class Job:
         self._always_run: bool = False
         self._preemptible: Optional[bool] = None
         self._machine_type: Optional[str] = None
+        self._pool_name: Optional[str] = None
         self._timeout: Optional[Union[int, float]] = None
         self._cloudfuse: List[Tuple[str, str, bool]] = []
         self._env: Dict[str, str] = {}


### PR DESCRIPTION
Example use case: after adding seqr-specific pools (see `add-seqr-pools.sql`), this will allow to schedule a job on a dedicated seqr pool by setting `job._pool_label = 'seqr'`. This way, we can limit the number of worker instances for the seqr loading pipeline, thereby avoiding starvation of other batches due to running over cloud provider quota.