### PR TITLE
Revert "[fs] Fix incorrect seeking semantics of GoogleStorageFS"

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -11,12 +11,12 @@ import is.hail.io.fs.FSUtil.{containsWildcard, dropTrailingSlash}
 import org.apache.log4j.Logger
 
 import java.net.URI
-import is.hail.utils.{defaultJSONFormats, fatal}
+import is.hail.utils.{fatal, defaultJSONFormats}
 import org.json4s
 import org.json4s.jackson.JsonMethods
 import org.json4s.Formats
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, FileNotFoundException, OutputStream}
+import java.io.{ByteArrayInputStream, FileNotFoundException, OutputStream}
 import java.nio.file.FileSystems
 import java.time.Duration
 import scala.collection.mutable
@@ -136,8 +136,6 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
 
     val is: SeekableInputStream = new FSSeekableInputStream {
       private[this] val client: BlobClient = blobClient
-
-      override def physicalSeek(newPos: Long): Unit = ()
 
       override def fill(): Int = {
         val pos = getPosition

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -1,20 +1,20 @@
 package is.hail.io.fs
 
+import java.io._
+import java.nio.charset._
+import java.util.zip.GZIPOutputStream
+import is.hail.{HailContext, HailFeatureFlags}
 import is.hail.backend.BroadcastValue
 import is.hail.io.compress.{BGzipInputStream, BGzipOutputStream}
 import is.hail.io.fs.FSUtil.{containsWildcard, dropTrailingSlash}
-import is.hail.services._
 import is.hail.utils._
-import is.hail.{HailContext, HailFeatureFlags}
+import is.hail.services._
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop
 
-import java.io._
 import java.nio.ByteBuffer
-import java.nio.charset._
 import java.nio.file.FileSystems
-import java.util.zip.GZIPOutputStream
 import scala.collection.mutable
 import scala.io.Source
 
@@ -153,8 +153,6 @@ abstract class FSSeekableInputStream extends InputStream with Seekable {
     toTransfer
   }
 
-  protected def physicalSeek(newPos: Long): Unit
-
   def seek(newPos: Long): Unit = {
     val distance = newPos - pos
     val bufferSeekPosition = bb.position() + distance
@@ -222,7 +220,6 @@ object FS {
         case cloud =>
           throw new IllegalArgumentException(s"Bad cloud: $cloud")
       }
-      physicalSeek(newPos)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -1,6 +1,5 @@
 package is.hail.io.fs
 
-
 import java.io.{ByteArrayInputStream, FileNotFoundException}
 import java.net.URI
 import java.nio.ByteBuffer
@@ -209,7 +208,8 @@ class GoogleStorageFS(
         return n
       }
 
-      override def physicalSeek(newPos: Long): Unit = {
+      override def seek(newPos: Long): Unit = {
+        super.seek(newPos)
         seekHandlingRequesterPays(newPos)
       }
     }


### PR DESCRIPTION
Reverts populationgenomics/hail#244

Doesn't compile at our current HEAD:
```
[Error] /io/repo/hail/src/main/scala/is/hail/io/fs/FS.scala:225: not found: value physicalSeek
[Error] /io/repo/hail/src/main/scala/is/hail/io/fs/FS.scala:225: not found: value newPos
```