### PR TITLE
Revert instrumentation

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -157,8 +157,6 @@ object Worker {
         writeString(dos, shortMessage)
         writeString(dos, expandedMessage)
         dos.writeInt(errorId)
-        log.info(s"job $i/$n failed with user exception: $shortMessage (error id $errorId)\n  $expandedMessage")
-        throw userError
       }
     }
     timer.end("writeOutputs")

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -361,13 +361,8 @@ case class IEmitCodeGen[+A](Lmissing: CodeLabel, Lpresent: CodeLabel, value: A, 
     value
   }
 
-  def get(cb: EmitCodeBuilder, errorMsg: Code[String]=null, errorID: Code[Int] = const(ErrorIDs.NO_ERROR)): A = {
-    val msg: Code[String] = if (errorMsg != null)
-      errorMsg
-    else
-      s"expected non-missing - compiler stacktrace: \n  ${Thread.currentThread().getStackTrace.mkString("\n  ")}"
-    handle(cb, cb._fatalWithError(errorID, msg))
-  }
+  def get(cb: EmitCodeBuilder, errorMsg: Code[String]=s"expected non-missing", errorID: Code[Int] = const(ErrorIDs.NO_ERROR)): A =
+    handle(cb, cb._fatalWithError(errorID, errorMsg))
 
   def consume(cb: EmitCodeBuilder, ifMissing: => Unit, ifPresent: (A) => Unit): Unit = {
     val Lafter = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1060,14 +1060,7 @@ case class PartitionZippedIndexedNativeReader(specLeft: AbstractTypedCodecSpec, 
 
           cb.ifx(endIndex > startIndex, {
             val leafNode = indexResult.loadField(cb, 2)
-              .handle(cb, {
-                cb._fatal("leaf node missing!",
-                  "\n  context: ", cb.strValue(ctxStruct),
-                  "\n  query result: ", cb.strValue(indexResult),
-                  "\n  first leaf: ", index.queryIndex(cb, outerRegion, 0L),
-                  "\n  last leaf: ", index.queryLastIndex(cb, outerRegion)
-                )
-              })
+              .get(cb)
               .asBaseStruct
 
             val leftSeekAddr = leftOffsetFieldIndex match {

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1064,8 +1064,8 @@ case class PartitionZippedIndexedNativeReader(specLeft: AbstractTypedCodecSpec, 
                 cb._fatal("leaf node missing!",
                   "\n  context: ", cb.strValue(ctxStruct),
                   "\n  query result: ", cb.strValue(indexResult),
-                  "\n  first leaf: ", cb.strValue(index.queryIndex(cb, outerRegion, 0L)),
-                  "\n  last leaf: ", cb.strValue(index.queryLastIndex(cb, outerRegion))
+                  "\n  first leaf: ", index.queryIndex(cb, outerRegion, 0L),
+                  "\n  last leaf: ", index.queryLastIndex(cb, outerRegion)
                 )
               })
               .asBaseStruct

--- a/hail/src/main/scala/is/hail/io/index/StagedIndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/StagedIndexReader.scala
@@ -156,8 +156,7 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
     }, region, partitionBoundLeftEndpoint, leansRight)
   }
 
-  def queryLastIndex(cb: EmitCodeBuilder, region: Value[Region]): SBaseStructValue = {queryIndex(cb, region, cb.memoize(cb.memoize(metadata.invoke[Long]("nKeys"))-1))}
-  def queryIndex(cb: EmitCodeBuilder, region: Value[Region], absIndex: Value[Long]): SBaseStructValue = {
+  private def queryIndex(cb: EmitCodeBuilder, region: Value[Region], absIndex: Value[Long]): SBaseStructValue = {
     cb.invokeSCode(
       cb.emb.ecb.getOrGenEmitMethod("queryIndex",
         ("queryIndex", this),

--- a/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -7,8 +7,6 @@ class HailException(val msg: String, val logMsg: Option[String], cause: Throwabl
   def this(msg: String, errorId: Int) = this(msg, None, null, errorId)
 }
 
-class HailWorkerFailure(msg: String, cause: Throwable) extends RuntimeException(msg)
-
 class HailWorkerException(
   val shortMessage: String,
   val expandedMessage: String,


### PR DESCRIPTION
To simplify an upcoming upstream merge, revert all recent instrumentation added to help Tim Poterba fix a bug (which has been resolved).