### PR TITLE
Fix dataproc start: remove "-r requirements" from pip_dependencies in deploy.yaml

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -280,7 +280,7 @@ python/hailtop/hailctl/deploy.yaml: $(resources) python/requirements.txt
 	for FILE in $(notdir $(resources)); do \
 	  echo "  $$FILE: $(cloud_base)/$$FILE" >> $@ || exit 1; done
 	echo "  wheel: $(wheel_cloud_path)" >> $@
-	echo "  pip_dependencies: $(shell cat python/requirements.txt | sed '/^[[:blank:]]*#/d;s/#.*//' | grep -v pyspark | tr "\n" "|||")" >> $@
+	echo "  pip_dependencies: $(shell cat python/requirements.txt python/hailtop/requirements.txt | grep '^\-r ' | sed '/^[[:blank:]]*#/d;s/#.*//' | grep -v pyspark | tr "\n" "|||")" >> $@
 
 .PHONY: upload-artifacts
 upload-artifacts: $(WHEEL)


### PR DESCRIPTION
Addresses

```
pip packages are ['setuptools', 'mkl<2020', 'lxml<5', 'google-cloud-storage==1.25.*', 'https://github.com/hail-is/jgscm/archive/v0.1.12+hail.zip', 'ipykernel==4.10.*', 'ipywidgets==7.5.*', 'jupyter-console==6.0.*', 'nbconvert==5.6.*', 'notebook==5.7.*', 'qtconsole==4.5.*', 'sklearn', 'slackclient', 'google', 'cpg-utils', '-r hailtop/requirements.txt', 'asyncinit>=0.2.4,<0.3', 'avro>=1.10,<1.12', 'bokeh==1.4.0', 'decorator<5', 'Deprecated>=1.2.10,<1.3', 'dill>=0.3.1.1,<0.4', 'frozenlist>=1.3.1,<2', 'hurry.filesize>=0.9,<1', 'Jinja2==3.0.3', 'nest_asyncio>=1.5.4,<2', 'numpy<2', 'pandas>=1.3.0,<1.5.0', 'parsimonious<0.9', 'plotly>=5.5.0,<5.11', 'protobuf==3.20.2', 'PyJWT', 'requests>=2.25.1,<3', 'scipy>1.2,<1.10', 'selenium', 'click', 'fsspec', 'gcloud', 'gnomad']
ERROR: Could not open requirements file: [Errno 2] No such file or directory: ' hailtop/requirements.txt'
```

Issue introduced in https://github.com/hail-is/hail/pull/12446

Context https://centrepopgen.slack.com/archives/C030X7WGFCL/p1669250748682069?thread_ts=1669161375.010299&cid=C030X7WGFCL