### PR TITLE
Restore printing of child batch URLs

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -765,14 +765,15 @@ class ServiceBackend(Backend[bc.Batch]):
 
         jobs_to_command = {j.id: cmd for j, cmd in jobs_to_command.items()}
 
+        deploy_config = get_deploy_config()
+        url = deploy_config.external_url('batch', f'/batches/{batch_handle.id}')
+        print(f'Submitted batch {batch_handle.id}, see {url}')
+
         if verbose:
-            print(f'Submitted batch {batch_handle.id} with {n_jobs_submitted} jobs in {round(time.time() - submit_batch_start, 3)} seconds:')
+            print(f'Batch consists of {n_jobs_submitted} jobs, submitted in {round(time.time() - submit_batch_start, 3)} seconds:')
             for jid, cmd in jobs_to_command.items():
                 print(f'{jid}: {cmd}')
             print('')
-
-        deploy_config = get_deploy_config()
-        url = deploy_config.external_url('batch', f'/batches/{batch_handle.id}')
 
         if open:
             webbrowser.open(url)


### PR DESCRIPTION
Context: https://centrepopgen.slack.com/archives/C03FZL2EF24/p1671168928439169

The previous print statement got removed in https://github.com/hail-is/hail/pull/12346/files#diff-40ac9d46c265cba91379598005c18322860f14a430de7cab77182d2083683be1.