### PR TITLE
add resize to cmd pre

### DIFF
--- a/batch/batch/front_end/templates/job.html
+++ b/batch/batch/front_end/templates/job.html
@@ -193,7 +193,7 @@
       <td>command</td>
       <td>
         <pre
-          style="max-height: 10em; max-width: 80em;">{{ "'" + (job_specification['command'] | join("' '")) + "'" }}</pre>
+          style="resize: both; width: 2020px; height: 620px;">{{ "'" + (job_specification['command'] | join("' '")) + "'" }}</pre>
       </td>
     </tr>
     {% for resource, value in job_specification['resources'].items() %}


### PR DESCRIPTION
QOL fix. Allow the cmd pre element to be resized by drag and drop by the user. This keeps the element compact by default, but lets the user not read the cmd through a letter box.

Tested by editing the style in the browser.