### PR TITLE
Add quick links to job types in batch

### DIFF
--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -15,7 +15,11 @@
   <li>Time Completed: {% if 'time_completed' in batch and batch['time_completed'] is not none %}{{ batch['time_completed'] }}{% endif %}</li>
   <li>Total Jobs: {{ batch['n_jobs'] }}</li>
   <ul>
-    <li>Pending Jobs: {{ batch['n_jobs'] - batch['n_completed'] }}</li>
+    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=pending">Pending</a>
+      + <a href="{{ base_path }}/batches/{{ batch['id'] }}?q=running">Running</a> Jobs: {{ batch['n_jobs'] - batch['n_completed'] }}</li>
+    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=success">Succeeded Jobs:</a> {{ batch['n_succeeded'] }}</li>
+    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=failed">Failed Jobs:</a> {{ batch['n_failed'] }}</li>
+    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=cancelled">Cancelled Jobs::</a> {{ batch['n_cancelled'] }}</li>
     <li>Succeeded Jobs: {{ batch['n_succeeded'] }}</li>
     <li>Failed Jobs: {{ batch['n_failed'] }}</li>
     <li>Cancelled Jobs: {{ batch['n_cancelled'] }}</li>

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -17,9 +17,9 @@
   <ul>
     <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=pending">Pending</a>
       + <a href="{{ base_path }}/batches/{{ batch['id'] }}?q=running">Running</a> Jobs: {{ batch['n_jobs'] - batch['n_completed'] }}</li>
-    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=success">Succeeded</a>  Jobs: {{ batch['n_succeeded'] }}</li>
+    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=success">Succeeded</a> Jobs: {{ batch['n_succeeded'] }}</li>
     <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=failed">Failed</a> Jobs: {{ batch['n_failed'] }}</li>
-    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=cancelled">Cancelled</a>  Jobs: {{ batch['n_cancelled'] }}</li>
+    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=cancelled">Cancelled</a> Jobs: {{ batch['n_cancelled'] }}</li>
   </ul>
   <li>Duration: {% if 'duration' in batch and batch['duration'] is not none %}{{ batch['duration'] }}{% endif %}</li>
   <li>Cost: {% if 'cost' in batch and batch['cost'] is not none %}{{ batch['cost'] }}{% endif %}</li>

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -20,9 +20,6 @@
     <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=success">Succeeded</a>  Jobs: {{ batch['n_succeeded'] }}</li>
     <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=failed">Failed</a> Jobs: {{ batch['n_failed'] }}</li>
     <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=cancelled">Cancelled</a>  Jobs: {{ batch['n_cancelled'] }}</li>
-    <li>Succeeded Jobs: {{ batch['n_succeeded'] }}</li>
-    <li>Failed Jobs: {{ batch['n_failed'] }}</li>
-    <li>Cancelled Jobs: {{ batch['n_cancelled'] }}</li>
   </ul>
   <li>Duration: {% if 'duration' in batch and batch['duration'] is not none %}{{ batch['duration'] }}{% endif %}</li>
   <li>Cost: {% if 'cost' in batch and batch['cost'] is not none %}{{ batch['cost'] }}{% endif %}</li>

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -17,9 +17,9 @@
   <ul>
     <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=pending">Pending</a>
       + <a href="{{ base_path }}/batches/{{ batch['id'] }}?q=running">Running</a> Jobs: {{ batch['n_jobs'] - batch['n_completed'] }}</li>
-    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=success">Succeeded Jobs:</a> {{ batch['n_succeeded'] }}</li>
-    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=failed">Failed Jobs:</a> {{ batch['n_failed'] }}</li>
-    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=cancelled">Cancelled Jobs::</a> {{ batch['n_cancelled'] }}</li>
+    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=success">Succeeded</a>  Jobs: {{ batch['n_succeeded'] }}</li>
+    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=failed">Failed</a> Jobs: {{ batch['n_failed'] }}</li>
+    <li><a href="{{ base_path }}/batches/{{ batch['id'] }}?q=cancelled">Cancelled</a>  Jobs: {{ batch['n_cancelled'] }}</li>
     <li>Succeeded Jobs: {{ batch['n_succeeded'] }}</li>
     <li>Failed Jobs: {{ batch['n_failed'] }}</li>
     <li>Cancelled Jobs: {{ batch['n_cancelled'] }}</li>


### PR DESCRIPTION
Another QOL change. Adds quick links to filter jobs by status. Just easier than having to type in text box for common actions.

I have not actually tested this renders as expected.Is it easy to run up a local instance? 