### PR TITLE
Add endpoint that fetches completed batches in order

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -56,7 +56,7 @@ def batch_record_to_dict(record):
         'time_completed': time_completed,
         'duration': duration,
         'msec_mcpu': record['msec_mcpu'],
-        'cost': coalesce(record['cost'], 0),
+        'cost': coalesce(record.get('cost'), 0),
     }
 
     attributes = json.loads(record['attributes'])

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -86,7 +86,7 @@ def job_record_to_dict(record, name):
         'state': record['state'],
         'exit_code': exit_code,
         'duration': duration,
-        'cost': coalesce(record['cost'], 0),
+        'cost': coalesce(record.get('cost'), 0),
         'msec_mcpu': record['msec_mcpu'],
     }
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -435,7 +435,12 @@ async def get_completed_batches_ordered_by_completed_time(request, userdata):
         wheres.append('time_completed < %s')
 
     sql = f"""
-SELECT batches.*
+SELECT batches.*,
+    batches_cancelled.id IS NOT NULL AS cancelled,
+    batches_n_jobs_in_complete_states.n_completed,
+    batches_n_jobs_in_complete_states.n_succeeded,
+    batches_n_jobs_in_complete_states.n_failed,
+    batches_n_jobs_in_complete_states.n_cancelled
 FROM batches
 LEFT JOIN billing_projects
     ON batches.billing_project = billing_projects.name

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -429,7 +429,7 @@ async def get_completed_batches_ordered_by_completed_time(request, userdata):
         'NOT deleted',
     ]
 
-    limit = 300
+    limit = 100
     query_limit: str = request.query.get('limit')
     if query_limit:
         try:

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -768,6 +768,51 @@ async def get_job_container_log(request, batch_id):
     return web.Response(body=job_log)
 
 
+@routes.get('/api/v1alpha/batches/finished')
+@rest_billing_project_users_only
+async def get_completed_batches_ordered_by_completed_time(request, userdata):
+    db = request.app['db']
+    where_args = [userdata['username']]
+    wheres = [
+        'billing_project_users.`user` = %s',
+        'billing_project_users.billing_project = batches.billing_project',
+        'time_completed IS NOT NULL',
+        'NOT deleted',
+    ]
+
+    last_completed_timestamp = request.query.get('last_completed_timestamp')
+    if last_completed_timestamp:
+        where_args.append(last_completed_timestamp)
+        wheres.append('time_completed < %s')
+
+    sql = f"""
+SELECT batches.*
+FROM batches
+LEFT JOIN billing_projects
+    ON batches.billing_project = billing_projects.name
+LEFT JOIN batches_n_jobs_in_complete_states
+    ON batches.id = batches_n_jobs_in_complete_states.id
+LEFT JOIN batches_cancelled
+    ON batches.id = batches_cancelled.id
+STRAIGHT_JOIN billing_project_users
+    ON batches.billing_project = billing_project_users.billing_project
+WHERE
+    {' AND '.join(wheres)}
+ORDER BY time_completed DESC
+LIMIT 51;
+    """
+
+    batches = [
+        batch_record_to_dict(batch)
+        async for batch in db.select_and_fetchall(sql, where_args, query_name='get_completed_batches')
+    ]
+
+    body = {'batches': batches}
+    if len(batches) == 51:
+        body['last_completed_timestamp'] = batches[-1]['time_completed']
+    return web.json_response(body)
+
+
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log/{container}')
 @rest_billing_project_users_only
 async def rest_get_job_container_log(request, userdata, batch_id):  # pylint: disable=unused-argument


### PR DESCRIPTION
Explain plan: Looks like it's filtering on an index `batches_time_completed`, so should filter and sort quickly.

```
-> Limit: 51 row(s)  (cost=308316.58 rows=51) (actual time=0.074..0.520 rows=51 loops=1)
    -> Nested loop inner join  (cost=308316.58 rows=92069) (actual time=0.072..0.515 rows=51 loops=1)
        -> Nested loop left join  (cost=276092.43 rows=92069) (actual time=0.063..0.475 rows=51 loops=1)
            -> Nested loop left join  (cost=180570.84 rows=92069) (actual time=0.049..0.296 rows=51 loops=1)
                -> Nested loop left join  (cost=79778.30 rows=92069) (actual time=0.043..0.191 rows=51 loops=1)
                    -> Filter: (batches.deleted = 0)  (cost=47554.15 rows=92069) (actual time=0.032..0.147 rows=51 loops=1)
                        -> Index range scan on batches using batches_time_completed, with index condition: (batches.time_completed is not null)  (cost=47554.15 rows=184138) (actual time=0.030..0.140 rows=51 loops=1)
                    -> Single-row index lookup on billing_projects using PRIMARY (name=batches.billing_project)  (cost=0.25 rows=1) (actual time=0.000..0.001 rows=1 loops=51)
                -> Single-row index lookup on batches_n_jobs_in_complete_states using PRIMARY (id=batches.id)  (cost=0.99 rows=1) (actual time=0.002..0.002 rows=1 loops=51)
            -> Single-row index lookup on batches_cancelled using PRIMARY (id=batches.id)  (cost=0.94 rows=1) (actual time=0.003..0.003 rows=0 loops=51)
        -> Single-row index lookup on billing_project_users using PRIMARY (billing_project=batches.billing_project, user='$USER')  (cost=0.25 rows=1) (actual time=0.001..0.001 rows=1 loops=51)
```