### PR TITLE
Fix-hail-node-pool-sql-error

### DIFF
--- a/batch/batch/inst_coll_config.py
+++ b/batch/batch/inst_coll_config.py
@@ -104,7 +104,7 @@ SET worker_cores = %s,
     autoscaler_loop_period_secs = %s,
     worker_max_idle_time_secs = %s,
     standing_worker_max_idle_time_secs = %s,
-    job_queue_scheduling_window_secs = %s
+    job_queue_scheduling_window_secs = %s,
     label = %s
 WHERE pools.name = %s;
 ''',


### PR DESCRIPTION
Small bug, but prevents any node pool updates because of the SQL syntax error near the `label = `. Deduced that there was a missing `,` on the previous line.