### PR TITLE
[services] indicate how many errors we have seen

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -797,7 +797,7 @@ async def retry_transient_errors_with_debug_string(debug_string: str, warning_de
             if errors == 1 and is_retry_once_error(e):
                 return await f(*args, **kwargs)
             if not is_transient_error(e):
-                raise
+                raise ValueError(f"errors={errors}, delay={delay}") from e
             log_warnings = (time_msecs() - start_time >= warning_delay_msecs) or not is_delayed_warning_error(e)
             if log_warnings and errors == 2:
                 log.warning(f'A transient error occured. We will automatically retry. Do not be alarmed. '

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -128,7 +128,7 @@ package object services {
           if (errors == 1 && isRetryOnceError(e))
             return f
           if (!isTransientError(e))
-            throw e
+            throw new RuntimeException(s"errors=$errors, delay=$delay", e)
           if (errors % 10 == 0)
             log.warn(s"encountered $errors transient errors, most recent one was $e")
       }


### PR DESCRIPTION
Cherry-picking https://github.com/hail-is/hail/pull/12984/commits (see https://hail.zulipchat.com/#narrow/stream/123010-Hail-Query-0.2E2-support/topic/SocketException.20when.20writing.20Table/near/355889336).

We are increasingly seeing errors from "Connection reset" which we switched from "transient" to "retry once". The current code makes it impossible to determine if we are correctly retrying this error once.

If we see that there are a lot of "Connection reset" errors that happen twice we should perhaps change "retry once" to "retry five times" or use a more generous delay.