### PR TITLE
Revert "[services] indicate how many errors we have seen"

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -797,7 +797,7 @@ async def retry_transient_errors_with_debug_string(debug_string: str, warning_de
             if errors == 1 and is_retry_once_error(e):
                 return await f(*args, **kwargs)
             if not is_transient_error(e):
-                raise ValueError(f"errors={errors}, delay={delay}") from e
+                raise
             log_warnings = (time_msecs() - start_time >= warning_delay_msecs) or not is_delayed_warning_error(e)
             if log_warnings and errors == 2:
                 log.warning(f'A transient error occured. We will automatically retry. Do not be alarmed. '

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -128,7 +128,7 @@ package object services {
           if (errors == 1 && isRetryOnceError(e))
             return f
           if (!isTransientError(e))
-            throw new RuntimeException(s"errors=$errors, delay=$delay", e)
+            throw e
           if (errors % 10 == 0)
             log.warn(s"encountered $errors transient errors, most recent one was $e")
       }


### PR DESCRIPTION
Reverts populationgenomics/hail#288

> By converting that error from a 404 to a different exception, Hail fails to correctly identify folder existence
(https://hail.zulipchat.com/#narrow/stream/123010-Hail-Query-0.2E2-support/topic/SocketException.20when.20writing.20Table/near/356044721)