### PR TITLE
FIX: storage accounts weren't unique. Added prefix. Fixed zone bug in…

### DIFF
--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -94,6 +94,7 @@ module "batch" {
   batch_test_user_storage_account_name = var.batch_test_user_storage_account_name
   resource_group        = data.azurerm_resource_group.rg
   container_registry_id = azurerm_container_registry.acr.id
+  storage_account_suffix = var.storage_account_suffix
 }
 
 module "global_config" {
@@ -132,4 +133,5 @@ module "ci" {
   github_context                          = var.ci_config.github_context
   ci_and_deploy_github_oauth_token        = var.ci_config.ci_and_deploy_github_oauth_token
   ci_test_repo_creator_github_oauth_token = var.ci_config.ci_test_repo_creator_github_oauth_token
+  storage_account_suffix                  = var.storage_account_suffix
 }

--- a/infra/azure/modules/batch/main.tf
+++ b/infra/azure/modules/batch/main.tf
@@ -50,7 +50,7 @@ resource "kubernetes_secret" "batch_worker_ssh_public_key" {
 }
 
 resource "azurerm_storage_account" "batch" {
-  name                     = "${var.resource_group.name}batch"
+  name                     = "${var.resource_group.name}batch${var.storage_account_suffix}"
   resource_group_name      = var.resource_group.name
   location                 = var.resource_group.location
   account_tier             = "Standard"
@@ -74,7 +74,7 @@ resource "azurerm_storage_container" "query" {
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "${var.batch_test_user_storage_account_name}test"
+  name                     = "${var.batch_test_user_storage_account_name}test${var.storage_account_suffix}"
   resource_group_name      = var.resource_group.name
   location                 = var.resource_group.location
   account_tier             = "Standard"

--- a/infra/azure/modules/batch/variables.tf
+++ b/infra/azure/modules/batch/variables.tf
@@ -13,3 +13,7 @@ variable batch_test_user_storage_account_name {
 variable container_registry_id {
   type = string
 }
+
+variable storage_account_suffix {
+  type = string
+}

--- a/infra/azure/modules/ci/main.tf
+++ b/infra/azure/modules/ci/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "ci" {
-  name                     = "${var.resource_group.name}ci"
+  name                     = "${var.resource_group.name}ci${var.storage_account_suffix}"
   resource_group_name      = var.resource_group.name
   location                 = var.resource_group.location
   account_tier             = "Standard"

--- a/infra/azure/modules/ci/variables.tf
+++ b/infra/azure/modules/ci/variables.tf
@@ -36,3 +36,7 @@ variable "deploy_steps" {
 variable "github_context" {
   type = string
 }
+
+variable "storage_account_suffix" {
+  type = string
+}

--- a/infra/azure/modules/db/main.tf
+++ b/infra/azure/modules/db/main.tf
@@ -36,7 +36,14 @@ resource "azurerm_mysql_flexible_server" "db" {
   # Which availability zone (out of 1,2,3) that the database should be hosted
   # in. This should ideally match the zone that batch is in but we don't have
   # availability zones enabled in AKS.
-  zone = 1
+  # Commented out due to the following error:
+  # │ Error: waiting for creation of Flexible Server: (Name "db-2138b3b3" / Resource Group "hail"): Code="AvailableZoneNotFound" Message="The availiabilityZone '1' is not found for subscription id '4453ab2e-2015-4bf0-adf2-7b2fa1f207e3'."
+  # │ 
+  # │   with module.db.azurerm_mysql_flexible_server.db,
+  # │   on modules/db/main.tf line 22, in resource "azurerm_mysql_flexible_server" "db":
+  # │   22: resource "azurerm_mysql_flexible_server" "db" {
+  # │ 
+  # zone = 1
 
   delegated_subnet_id = var.subnet_id
   private_dns_zone_id = azurerm_private_dns_zone.db.id

--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -59,3 +59,7 @@ variable oauth2_developer_redirect_uris {
   type    = list(string)
   default = []
 }
+
+variable storage_account_suffix {
+  type = string
+}


### PR DESCRIPTION
The storage accounts were no longer unique. I've added in a `storage_account_suffix` argument in order to resolve this issue.

The other bug was that the `zone` argument for the flexible mysql server no longer has any valid options in the Australia East region. I've commented it out with the error I noticed. Happy to clean up/remove that comment if we'd prefer it to not be there.

