### PR TITLE
Allow prod_deploy to be hit by non-developer CI

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -527,12 +527,12 @@ async def dev_deploy_branch(request: web.Request, userdata: UserData) -> web.Res
 
 # This is CPG-specific, as the Hail team redeploys by watching the main branch.
 @routes.post('/api/v1alpha/prod_deploy')
-@auth.authenticated_developers_only()
+@auth.authenticated_users_only()
 async def prod_deploy(request, userdata):
     """Deploys the main branch to the production namespace ("default")."""
     # Only allow access by "ci" or dev accounts.
     if not (userdata['username'] == 'ci' or userdata['is_developer'] == 1):
-        raise web.HTTPUnauthorized()
+        raise web.HTTPForbidden(text='Not a developer OR ci')
     app = request.app
     try:
         params = await request.json()


### PR DESCRIPTION
Erroneously tagged the endpoint with developers which blocks CI. I've manually updated ci to a developer, but we should fix this then undo. Added a better error message for Forbidden to help track auth issues in the future.