### PR TITLE
Update CPG-local step after upstream wheel-container.tar refactor

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3410,15 +3410,14 @@ steps:
       valueFrom: ci_utils_image.image
     script: |
       set -ex
-      tar xvf /io/wheel-container.tar
       gcloud auth activate-service-account --key-file=/gsa-key/key.json
       HAIL_WHEEL_FILE=hail-$(cat /io/hail_pip_version)-py3-none-any.whl
-      gcloud storage cp "$HAIL_WHEEL_FILE" "gs://cpg-hail-ci/wheels/$HAIL_WHEEL_FILE"
+      gcloud storage cp "/io/wheel/$HAIL_WHEEL_FILE" "gs://cpg-hail-ci/wheels/$HAIL_WHEEL_FILE"
     inputs:
       - from: /hail_pip_version
         to: /io/hail_pip_version
-      - from: /wheel-container.tar
-        to: /io/wheel-container.tar
+      - from: /wheel
+        to: /io/wheel
     scopes:
       - deploy
       - dev


### PR DESCRIPTION
Upstream's hail-is/hail#13912 (see [lines 754–766](https://github.com/hail-is/hail/pull/13912/files#diff-2f7f69286606c0ff1642fac8ecb40ee91874b65bb544af172e32552c91a44799)) changed this to copy a .whl file in a subdirectory around, instead of tarring/untarring it for no real reason.