### PR TITLE
Fix merge error and reorder to reduce the difference from upstream backend.py

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -843,16 +843,17 @@ class ServiceBackend(Backend[bc.Batch]):
 
         jobs_to_command = {j.id: cmd for j, cmd in jobs_to_command.items()}
 
-        deploy_config = get_deploy_config()
-        url = deploy_config.external_url('batch', f'/batches/{batch_handle.id}')
-
-        if not wait:
-            print(f'Submitted batch {batch_handle.id}, see {url}')
         if verbose:
             print(f'Submitted batch {batch_id} with {n_jobs_submitted} jobs in {round(time.time() - submit_batch_start, 3)} seconds:')
             for jid, cmd in jobs_to_command.items():
                 print(f'{jid}: {cmd}')
             print('')
+
+        deploy_config = get_deploy_config()
+        url = deploy_config.external_url('batch', f'/batches/{batch_id}')
+
+        if not wait:
+            print(f'Submitted batch {batch_id}, see {url}')
 
         if open:
             webbrowser.open(url)


### PR DESCRIPTION
During the previous merge I carefully merged _backend.py_, in which `batch_handle.id` gained `batch_id` as an alias, but they were equivalent so I left `batch_handle.id` as is in our patches.

During the 0.2.126 + fix-non-responsive-VMs merge, I didn't notice that ebfbc24e223aef893091ca9de4780b1be1023ad2 (committed only a few hours before the OOM fix!) refactored `batch_handle` out of existence. 😞 

This PR belatedly uses `batch_id` instead, and reorders this code so that only the `if not wait: print(…)` is simply added to upstream _backend.py_ rather than a more complex more conflict-prone change.

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1699929176858399