### PR TITLE
Disable trial_bp to alleviate error during user creation

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -10,15 +10,16 @@ import aiohttp
 import kubernetes_asyncio.client
 import kubernetes_asyncio.client.rest
 import kubernetes_asyncio.config
+from hailtop import aiotools
+from hailtop import batch_client as bc
+from hailtop import httpx
+from hailtop.aiocloud.aioazure import AzureGraphClient
+from hailtop.aiocloud.aiogoogle import GoogleIAmClient
+from hailtop.utils import secret_alnum_string, time_msecs
 
 from gear import Database, create_session
 from gear.clients import get_identity_client
 from gear.cloud_config import get_gcp_config, get_global_config
-from hailtop import aiotools, httpx
-from hailtop import batch_client as bc
-from hailtop.aiocloud.aioazure import AzureGraphClient
-from hailtop.aiocloud.aiogoogle import GoogleIAmClient
-from hailtop.utils import secret_alnum_string, time_msecs
 
 log = logging.getLogger('auth.driver')
 
@@ -442,7 +443,7 @@ WHERE id = %(id)s AND state = 'creating';
         raise DatabaseConflictError
 
 
-async def create_user(app, user, skip_trial_bp=False):
+async def create_user(app, user, skip_trial_bp=True):
     cleanup: List[Callable[[], Awaitable[None]]] = []
     try:
         await _create_user(app, user, skip_trial_bp, cleanup)

--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -442,6 +442,8 @@ WHERE id = %(id)s AND state = 'creating';
         raise DatabaseConflictError
 
 
+# 2023-11-16 mfranklin: disable trial bp because there's an auth problem
+#   https://hail.zulipchat.com/#narrow/stream/300487-Hail-Batch-Dev/topic/Issue.20creating.20users/near/401890787
 async def create_user(app, user, skip_trial_bp=True):
     cleanup: List[Callable[[], Awaitable[None]]] = []
     try:

--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -10,16 +10,15 @@ import aiohttp
 import kubernetes_asyncio.client
 import kubernetes_asyncio.client.rest
 import kubernetes_asyncio.config
-from hailtop import aiotools
-from hailtop import batch_client as bc
-from hailtop import httpx
-from hailtop.aiocloud.aioazure import AzureGraphClient
-from hailtop.aiocloud.aiogoogle import GoogleIAmClient
-from hailtop.utils import secret_alnum_string, time_msecs
 
 from gear import Database, create_session
 from gear.clients import get_identity_client
 from gear.cloud_config import get_gcp_config, get_global_config
+from hailtop import aiotools, httpx
+from hailtop import batch_client as bc
+from hailtop.aiocloud.aioazure import AzureGraphClient
+from hailtop.aiocloud.aiogoogle import GoogleIAmClient
+from hailtop.utils import secret_alnum_string, time_msecs
 
 log = logging.getLogger('auth.driver')
 


### PR DESCRIPTION
Currently there's an error when creating a user due to an auth problem when creating the trial billing project - we don't usually use these (it could be created manually anyway), so let's disable it for now.

Revert when this is resolved

More context:
https://hail.zulipchat.com/#narrow/stream/300487-Hail-Batch-Dev/topic/Issue.20creating.20users/near/401890787