### PR TITLE
Fix cherry-picking accident in recent auth bug fix

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -332,7 +332,7 @@ async def callback(request) -> web.Response:
     cleanup_session(session)
 
     try:
-        flow_client = request.app[AppKeys.FLOW_CLIENT]
+        flow_client = request.app['flow_client']
         flow_result = flow_client.receive_callback(request, flow_dict)
         login_id = flow_result.login_id
     except asyncio.CancelledError:


### PR DESCRIPTION
The recently cherry-picked CVE-2023-51663 fix (PR #323) included refactored code dependent on recent upstream code that was not cherry-picked. This caused:

```
{"severity":"ERROR","levelname":"ERROR","asctime":"2024-01-03 01:59:09,079","filename":"auth.py",
"funcNameAndLine":"callback:341","message":"oauth2 callback: could not fetch and verify token",
"exc_info":"Traceback (most recent call last):\n
File \"/usr/local/lib/python3.9/dist-packages/auth/auth.py\", line 335, in callback\n
    flow_client = request.app[AppKeys.FLOW_CLIENT]\n
NameError: name 'AppKeys' is not defined",
"hail_log":1}
```

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1704243108737559

Revert the affected line to use the previous literal string rather than the `AppKeys` class that does not yet exist on our branch.