### PR TITLE
Fix merge accident in recent auth bug fixes

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -332,7 +332,7 @@ async def callback(request) -> web.Response:
     cleanup_session(session)
 
     try:
-        flow_client = request.app['flow_client']
+        flow_client = request.app[AppKeys.FLOW_CLIENT]
         flow_result = flow_client.receive_callback(request, flow_dict)
         login_id = flow_result.login_id
     except asyncio.CancelledError:


### PR DESCRIPTION
PR #325 removed AppKeys.FLOW_CLIENT here as we did not cherry-pick the rest of the AppKeys change. We later applied PR #324 which fully merged upstream's AppKeys changes. Unfortunately when we merged that PR via GitHub it chose #325's version of this line. 🤦‍♂️ 

Context: https://centrepopgen.slack.com/archives/C03FZL2EF24/p1704686405642299