### PR TITLE
Update completed endpoint with new job group format

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -384,20 +384,32 @@ async def get_completed_batches_ordered_by_completed_time(request, userdata):
 
     sql = f"""
 SELECT batches.*,
-    batches_cancelled.id IS NOT NULL AS cancelled,
-    batches_n_jobs_in_complete_states.n_completed,
-    batches_n_jobs_in_complete_states.n_succeeded,
-    batches_n_jobs_in_complete_states.n_failed,
-    batches_n_jobs_in_complete_states.n_cancelled
+  job_groups_cancelled.id IS NOT NULL AS cancelled,
+  job_groups_n_jobs_in_complete_states.n_completed,
+  job_groups_n_jobs_in_complete_states.n_succeeded,
+  job_groups_n_jobs_in_complete_states.n_failed,
+  job_groups_n_jobs_in_complete_states.n_cancelled,
+  cost_t.*
 FROM batches
 LEFT JOIN billing_projects
     ON batches.billing_project = billing_projects.name
-LEFT JOIN batches_n_jobs_in_complete_states
-    ON batches.id = batches_n_jobs_in_complete_states.id
-LEFT JOIN batches_cancelled
-    ON batches.id = batches_cancelled.id
+LEFT JOIN job_groups_n_jobs_in_complete_states
+       ON batches.id = job_groups_n_jobs_in_complete_states.id
+LEFT JOIN job_groups_cancelled
+       ON batches.id = job_groups_cancelled.id
 STRAIGHT_JOIN billing_project_users
     ON batches.billing_project = billing_project_users.billing_project
+LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(`usage` * rate), 0) AS cost, JSON_OBJECTAGG(resources.resource, COALESCE(`usage` * rate, 0)) AS cost_breakdown
+    FROM (
+      SELECT batch_id, resource_id, CAST(COALESCE(SUM(`usage`), 0) AS SIGNED) AS `usage`
+      FROM aggregated_job_group_resources_v3
+      WHERE batches.id = aggregated_job_group_resources_v3.batch_id
+      GROUP BY batch_id, resource_id
+    ) AS usage_t
+    LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
+    GROUP BY batch_id
+  ) AS cost_t ON TRUE
 WHERE
     {' AND '.join(wheres)}
 ORDER BY time_completed DESC

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -394,9 +394,9 @@ FROM batches
 LEFT JOIN billing_projects
     ON batches.billing_project = billing_projects.name
 LEFT JOIN job_groups_n_jobs_in_complete_states
-       ON batches.id = job_groups_n_jobs_in_complete_states.id
+    ON batches.id = job_groups_n_jobs_in_complete_states.id
 LEFT JOIN job_groups_cancelled
-       ON batches.id = job_groups_cancelled.id
+    ON batches.id = job_groups_cancelled.id
 STRAIGHT_JOIN billing_project_users
     ON batches.billing_project = billing_project_users.billing_project
 LEFT JOIN LATERAL (


### PR DESCRIPTION
The latest change #324 (upstream from head) introduced a stronger job group concept which included a fairly sizeable migration, this new structure broke our `/completed` endpoint which we use for Hail / Seqr aggregation.

Rewrite the function to align back with the original function it was modelled off:
https://github.com/populationgenomics/hail/blob/01714cc51f092304eb7b4de47bdc2c7c192b13cd/batch/batch/front_end/front_end.py#L1714-L1739

I haven't tested the endpoint, but I've tested the query and it works.

Columns selected:

- id
- userdata
- user
- billing_project
- attributes
- callback
- deleted
- n_jobs
- time_created
- time_completed
- msec_mcpu
- token
- state
- format_version
- time_closed
- cancel_after_n_failures
- migrated_batch
- cancelled
- n_completed
- n_succeeded
- n_failed
- n_cancelled
- cost
- cost_breakdown