### PR TITLE
Expose job resource in batch API

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -523,7 +523,7 @@ async def get_jobs_for_billing(request, userdata, batch_id):
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/resource_usage')
 @billing_project_users_only()
-async def get_job_resource_usage(request, _, batch_id):
+async def get_job_resource_usage(request: web.Request, _, batch_id: int) -> web.Response:
     """
     Get the resource_usage data for a job. The data is returned as a JSON object
     transformed from a pandas DataFrame using the 'split' orientation.
@@ -545,7 +545,7 @@ async def get_job_resource_usage(request, _, batch_id):
             ],
             "index":[0, 1, ...],
             "data": [[<records>]],
-        }
+        }, ...
     }
     """
 


### PR DESCRIPTION
It's useful for us to be able to programmatically access the resource data from a job and batches.
This is stored as a dataframe, we'll send back as json with `orient='split'`.

I've tested this in a dev deploy, and worked fairly well.

In my own interest, here's how to convert it back into a dataframe:

```python
import pandas as pd

response = {} # response from Hail Batch
dataframes = {
    key: pd.DataFrame(data=values['data'], columns=values['columns'])
    for key, values in response.items()
}
```