### PR TITLE
Implement the metadata server .../service-accounts/.../scopes endpoint

### DIFF
--- a/batch/batch/cloud/gcp/worker/metadata_server.py
+++ b/batch/batch/cloud/gcp/worker/metadata_server.py
@@ -50,6 +50,11 @@ async def user_email(request: web.Request):
     return web.Response(text=request.app[AppKeys.USER_CREDENTIALS].email)
 
 
+async def user_scopes(request: web.Request):
+    text = '\n'.join(request.app[AppKeys.USER_CREDENTIALS]._scopes)
+    return web.Response(text=f'{text}\n')
+
+
 async def user_token(request: web.Request):
     access_token = await request.app[AppKeys.USER_CREDENTIALS]._get_access_token()
     return web.json_response({
@@ -101,6 +106,7 @@ def create_app(
         web.get('/computeMetadata/v1/instance/service-accounts/{gsa}', user_service_account),
         web.get('/computeMetadata/v1/instance/service-accounts/{gsa}/', user_service_account),
         web.get('/computeMetadata/v1/instance/service-accounts/{gsa}/email', user_email),
+        web.get('/computeMetadata/v1/instance/service-accounts/{gsa}/scopes', user_scopes),
         web.get('/computeMetadata/v1/instance/service-accounts/{gsa}/token', user_token),
     ])
 


### PR DESCRIPTION
Follow-up to PR #337, context: https://centrepopgen.slack.com/archives/C04M1G5HLM9/p1716767294970409?thread_ts=1716528932.818119&cid=C04M1G5HLM9

The code that parses this response (in _apitools/base/py/utils.py_'s `NormalizeScopes()`) appears to be wanting a whitespace-separated bunch of words. We write this one-per-line as per other endpoints, e.g. `user_service_account()`.