### PR TITLE
Add pool label to "resource requests ... are unsatisfiable" message

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1504,6 +1504,7 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
                 f'memory={resources.get("req_memory")}, '
                 f'storage={resources["req_storage"]}, '
                 f'preemptible={preemptible}, '
+                f'pool_label={pool_label}, '
                 f'machine_type={machine_type}'
             )
 


### PR DESCRIPTION
Pool labels are a CPG-local addition (added in PR #197) that are considered in `select_inst_coll()` so should be displayed in this error message — unfortunately we neglected to report them in the error message at the time.

I've verified that this is the only new `select_inst_coll()` parameter not represented in the error message (`worker_type` is also not directly printed, but it is derived within `_create_jobs()` from other fields rather than being a config field), and that there are no other similarly bereft error messages elsewhere.