### PR TITLE
Accumulated changes to apply before our next Hail uplift

### DIFF
--- a/batch/build-batch-worker-image-startup-gcp.sh
+++ b/batch/build-batch-worker-image-startup-gcp.sh
@@ -58,9 +58,10 @@ apt-get install -y g++-12
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 50
 update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 50
 
-wget --no-verbose https://us.download.nvidia.com/XFree86/Linux-x86_64/530.30.02/NVIDIA-Linux-x86_64-530.30.02.run
-chmod +x NVIDIA-Linux-x86_64-530.30.02.run
-./NVIDIA-Linux-x86_64-530.30.02.run --silent
+NVIDIA_VERSION=555.58.02
+wget --no-verbose https://us.download.nvidia.com/XFree86/Linux-x86_64/$NVIDIA_VERSION/NVIDIA-Linux-x86_64-$NVIDIA_VERSION.run
+chmod +x NVIDIA-Linux-x86_64-$NVIDIA_VERSION.run
+./NVIDIA-Linux-x86_64-$NVIDIA_VERSION.run --ui=none --no-questions > /var/log/nvidia-run.log
 
 apt-get --yes install nvidia-container-toolkit
 nvidia-ctk runtime configure --runtime=docker

--- a/batch/gcp-create-worker-image.sh
+++ b/batch/gcp-create-worker-image.sh
@@ -24,7 +24,7 @@ else
     BUILDER=build-batch-worker-$NAMESPACE-image
 fi
 
-UBUNTU_IMAGE=ubuntu-minimal-2204-jammy-v20230726
+UBUNTU_IMAGE=ubuntu-minimal-2204-jammy-v20240701
 
 create_build_image_instance() {
     gcloud -q compute --project ${PROJECT} instances delete \

--- a/build.yaml
+++ b/build.yaml
@@ -3436,18 +3436,12 @@ steps:
       valueFrom: ci_utils_image.image
     script: |
       set -ex
-      gcloud auth activate-service-account --key-file=/registry-push-credentials/credentials.json
       gcloud auth -q configure-docker australia-southeast1-docker.pkg.dev
       skopeo copy docker://{{ hailgenetics_hail_image.image }} docker://australia-southeast1-docker.pkg.dev/hail-295901/hail/hailgenetics/hail:$(cat /io/hail_pip_version)
       skopeo copy docker://{{ hailgenetics_hailtop_image.image }} docker://australia-southeast1-docker.pkg.dev/hail-295901/hail/hailgenetics/hailtop:$(cat /io/hail_pip_version)
     inputs:
       - from: /hail_pip_version
         to: /io/hail_pip_version
-    secrets:
-      - name: registry-push-credentials
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /registry-push-credentials
     scopes:
       - deploy
       - dev


### PR DESCRIPTION
* Rebuild of batch-worker-15. We will want to see how upstream handles this, but may want to merge this commit in any case as it reflects how we rebuilt the image.

* During the [last uplift](https://centrepopgen.slack.com/archives/C03FZL2EF24/p1716586854222869?thread_ts=1716253644.547219&cid=C03FZL2EF24), we had to omit a terraform change because one of our CPG-local additions still used `registry-push-credentials`, which hail-is/hail#14301 moved away from and hail-is/hail#14320 deleted.

   This follows the upstream pattern, using CI's creds already in `$GOOGLE_APPLICATION_CREDENTIALS` instead. That's presumably already activated for gcloud purposes, so we can remove the `activate-service-account` and need do nothing instead… 🤞 

When we come to start the next uplift, we can start from this branch. Or we may wish to merge this first (probably after we see how upstream handles the image rebuild), so that we can apply terraform fully during the subsequent eventual uplift.