### PR TITLE
Fix for /api/v1alpha/batches/completed, picking only ROOT_JOB_GROUP when collecting batches and jobs.

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -412,7 +412,7 @@ async def get_completed_batches_ordered_by_completed_time(request, userdata):
         wheres.append('batches.time_completed < %s')
 
     sql = f"""
-SELECT DISTINCT batches.*,
+SELECT batches.*,
   cancelled_t.cancelled IS NOT NULL AS cancelled,
   job_groups_n_jobs_in_complete_states.n_completed,
   job_groups_n_jobs_in_complete_states.n_succeeded,

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -389,12 +389,13 @@ async def _query_job_group_jobs(
 @auth.authenticated_users_only()
 async def get_completed_batches_ordered_by_completed_time(request, userdata):
     db = request.app['db']
-    where_args = [userdata['username']]
+    where_args = [userdata['username'], ROOT_JOB_GROUP_ID]
     wheres = [
         'billing_project_users.`user` = %s',
         'billing_project_users.billing_project = batches.billing_project',
         'batches.time_completed IS NOT NULL',
         'NOT deleted',
+        'job_groups.job_group_id = %s',
     ]
 
     limit = 100
@@ -411,7 +412,7 @@ async def get_completed_batches_ordered_by_completed_time(request, userdata):
         wheres.append('batches.time_completed < %s')
 
     sql = f"""
-SELECT batches.*,
+SELECT DISTINCT batches.*,
   cancelled_t.cancelled IS NOT NULL AS cancelled,
   job_groups_n_jobs_in_complete_states.n_completed,
   job_groups_n_jobs_in_complete_states.n_succeeded,


### PR DESCRIPTION
Current SQL to collect batch information is looping through all the job_groups.
In the function get_completed_batches_ordered_by_completed_time we are interested only in the top level per batch.
Without this fix the API is failing at this assert for Hail Query jobs:
https://github.com/populationgenomics/hail/blob/d65f84e8988c70bcaa2e10f2d2573ad3650d5b6d/batch/batch/batch.py#L35