### PR TITLE
Add support for public-ip-address in dataproc

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/cli.py
+++ b/hail/python/hailtop/hailctl/dataproc/cli.py
@@ -246,7 +246,7 @@ def start(
         requester_pays_allow_annotation_db,
         debug_mode,
         use_gcloud_beta,
-        public_ip_address=public_ip_address,
+        public_ip_address,
     )
 
 

--- a/hail/python/hailtop/hailctl/dataproc/cli.py
+++ b/hail/python/hailtop/hailctl/dataproc/cli.py
@@ -191,6 +191,9 @@ def start(
     debug_mode: Ann[
         bool, Opt(help='Enable debug features on created cluster (heap dump on out-of-memory error)')
     ] = False,
+    public_ip_address: Ann[
+        bool, Opt(help='Allow nodes to have a public IP address, and hence make requests on the public internet (default is internal-only from dataproc 2.2).')
+    ] = False,
 ):
     """
     Start a Dataproc cluster configured for Hail.
@@ -243,6 +246,7 @@ def start(
         requester_pays_allow_annotation_db,
         debug_mode,
         use_gcloud_beta,
+        public_ip_address=public_ip_address,
     )
 
 

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -177,6 +177,7 @@ def start(
     requester_pays_allow_annotation_db: bool,
     debug_mode: bool,
     beta: bool,
+    public_ip_address: bool,
 ):
     conf = ClusterConfig()
     conf.extend_flag('image-version', IMAGE_VERSION)
@@ -395,6 +396,8 @@ def start(
         cmd.append('--expiration_time={}'.format(expiration_time))
     if service_account:
         cmd.append('--service-account={}'.format(service_account))
+    if public_ip_address:
+        cmd.append('--public-ip-address')
 
     cmd.extend(pass_through_args)
 


### PR DESCRIPTION
Internal addresses only (no-address) is set by default when creating a Dataproc 2.2 image version cluster. You can use the gcloud dataproc clusters create --public-ip-address flag to enable public IP addresses. [[source](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/network#:~:text=Internal%20addresses%20only%20(no%2Daddress)%20is%20set%20by%20default%20when%20creating%20a%20Dataproc%202.2%20image%20version%20cluster.%20You%20can%20use%20the%20gcloud%20dataproc%20clusters%20create%20%2D%2Dpublic%2Dip%2Daddress%20flag%20to%20enable%20public%20IP%20addresses.)]

Old batch: https://batch.hail.populationgenomics.org.au/batches/474533/jobs/1
Which uses: `--image-version=2.1.2-debian11`

New batch: https://batch.hail.populationgenomics.org.au/batches/474657/jobs/1
Which uses `--image-version=2.2.5-debian12`

And the error just looks like a timeout for public requests (during cluster initialisation)