### PR TITLE
Hot fix from upstream PR 14754 to fix annoying UI Internal Server Error

### DIFF
--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -121,7 +121,7 @@ batch_state_indicator, job_state_indicator, danger_button, submit_button, link
     </div>
 
     <div class='pt-2 flex w-full justify-end'>
-      {% if batch['jobs'][0]['job_id'] is not none and batch['jobs'][0]['job_id'] > 1 %}
+      {% if batch['jobs'] and batch['jobs'][0]['job_id'] is not none and batch['jobs'][0]['job_id'] > 1 %}
         <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
           {% if q is not none %}
           <input type="hidden" name="q" value="{{ q }}" />


### PR DESCRIPTION
This PR cherry-picks hail-is/hail#14754 as a batch UI hot fix. This filtering issue is annoying enough that we'd like to deploy this fix without delay!

If your job filtering produced (e.g. unintentionally) zero jobs to be displayed, a trivial bug in this code would produce “jinja2.exceptions.UndefinedError: list object has no element 0” and an HTTP status 500 back to the user.

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1731022326797829