### PR TITLE
Set large StreamReadConstraints.maxStringLength for IR parsing only

### DIFF
--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -27,7 +27,6 @@ import scala.reflect.ClassTag
 import java.io._
 import java.nio.charset.StandardCharsets
 
-import com.fasterxml.jackson.core.StreamReadConstraints
 import org.json4s._
 import org.json4s.jackson.{JsonMethods, Serialization}
 
@@ -55,18 +54,6 @@ trait BackendContext {
 }
 
 abstract class Backend {
-  // From https://github.com/hail-is/hail/issues/14580 :
-  //   IR can get quite big, especially as it can contain an arbitrary
-  //   amount of encoded literals from the user's python session. This
-  //   was a (controversial) restriction imposed by Jackson and should be lifted.
-  //
-  // We remove this restriction for all backends, and we do so here, in the
-  // constructor since constructing a backend is one of the first things that
-  // happens and this constraint should be overrided as early as possible.
-  StreamReadConstraints.overrideDefaultStreamReadConstraints(
-    StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build()
-  )
-
   val persistedIR: mutable.Map[Int, BaseIR] = mutable.Map()
 
   protected[this] def addJavaIR(ir: BaseIR): Int = {

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -31,6 +31,7 @@ import java.io._
 import java.nio.charset.StandardCharsets
 import java.util.concurrent._
 
+import com.fasterxml.jackson.core.StreamReadConstraints
 import org.apache.log4j.Logger
 import org.json4s.{DefaultFormats, Formats}
 import org.json4s.JsonAST._
@@ -464,7 +465,12 @@ object ServiceBackendAPI {
 
     implicit val formats: Formats = DefaultFormats
 
+    StreamReadConstraints.overrideDefaultStreamReadConstraints(
+      StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build()
+    )
     val input = using(fs.openNoCompression(inputURL))(JsonMethods.parse(_))
+    StreamReadConstraints.overrideDefaultStreamReadConstraints(StreamReadConstraints.builder().build())
+
     val rpcConfig = (input \ "config").extract[ServiceBackendRPCPayload]
 
     // FIXME: when can the classloader be shared? (optimizer benefits!)


### PR DESCRIPTION
Enlarge the maxStringLength just before parsing the (perhaps huge!) IR and reset it to the default immediately afterwards.

If this code is multithreaded and other threads also parse JSON, there is a race condition here. It would be better to construct a bespoke JsonFactory to parse this IR, but expressing that while satisfying the type checker requires more Scala knowledge than we have.