### PR TITLE
Cherry-pick upstream fix: Set StreamReadConstraints maxStringLength as early as possible

### DIFF
--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -1,4 +1,5 @@
 import functools
+import random
 import re
 import unittest
 from test.hail.helpers import resource, skip_unless_spark_backend, skip_when_service_backend
@@ -774,3 +775,12 @@ def test_locus_interval_encoding():
     _assert_encoding_roundtrip(start)
     _assert_encoding_roundtrip(end)
     _assert_encoding_roundtrip(interval)
+
+
+def test_very_large_ir_deserializes():
+    # see: https://github.com/hail-is/hail/issues/14580
+    #      https://github.com/hail-is/hail/issues/14650
+    large_list = [random.getrandbits(63) for _ in range(5_000_000)]
+    large_lit = hl.literal(large_list, hl.tarray(hl.tint64))
+    round_trip = hl.eval(large_lit)
+    assert large_list == round_trip

--- a/hail/src/main/scala/is/hail/backend/service/Main.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Main.scala
@@ -1,8 +1,18 @@
 package is.hail.backend.service
 
+import com.fasterxml.jackson.core.StreamReadConstraints
+
 object Main {
   val WORKER = "worker"
   val DRIVER = "driver"
+
+  /* This constraint should be overridden as early as possible. See:
+   * - https://github.com/hail-is/hail/issues/14580
+   * - https://github.com/hail-is/hail/issues/14749
+   * - The note on this setting in is.hail.backend.Backend */
+  StreamReadConstraints.overrideDefaultStreamReadConstraints(
+    StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build()
+  )
 
   def main(argv: Array[String]): Unit =
     argv(3) match {


### PR DESCRIPTION
Cherry-pick upstream PR hail-is/hail#14750. As per https://github.com/hail-is/hail/pull/14750#issuecomment-2461801839 we were indeed seeing the “String length (20013488) exceeds the maximum length (20000000)” error on plain 0.2.133, so we do need to cherry-pick this for large Combiner jobs and the like.

This cherry-picks onto our **main** the same commit as in the previous **fixed-132-qob-jar** and **fixed-133-qob-jar** branches that were used to deploy (inefficiently built, as it turns out) QoB JARs.

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1734146403493839?thread_ts=1732046164.229849&cid=C030X7WGFCL