### PR TITLE
Update wheel input path to account for upstream change

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3500,7 +3500,7 @@ steps:
     inputs:
       - from: /repo
         to: /io/repo
-      - from: /wheel
+      - from: /derived/release/hail/build/deploy/dist
         to: /io/wheel
     scopes:
       - deploy


### PR DESCRIPTION
This changed in 6748990d4d13e7d9826f06d73ee045aa555d501c.
