### PR TITLE
Temporarily revert username validation, as new rule disallows dashes

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -129,7 +129,7 @@ async def check_valid_new_user(tx: Transaction, username, login_id, is_developer
         raise MultipleUserTypes(username)
     if not is_service_account and not login_id:
         raise EmptyLoginID(username)
-    if not username or not (username.isalnum() and username.islower()):
+    if not username or not all(c for c in username if c.isalnum()):
         raise InvalidUsername(username)
 
     existing_users = await users_with_username_or_login_id(tx, username, login_id)


### PR DESCRIPTION
This fix rolls back to the previous code prior to https://github.com/hail-is/hail/pull/14808

This is a temporary fix to unblock the creation of new users in our hail instance. The old code is also incorrect as it doesn't validate usernames at all.