### PR TITLE
Remove legacy google_container_registry terraform entries

### DIFF
--- a/infra/gcp/ci/main.tf
+++ b/infra/gcp/ci/main.tf
@@ -11,12 +11,6 @@ resource "google_storage_bucket_iam_member" "ci_bucket_admin" {
   member = "serviceAccount:${var.ci_email}"
 }
 
-resource "google_storage_bucket_iam_member" "ci_gcr_admin" {
-  bucket = var.container_registry_id
-  role = "roles/storage.admin"
-  member = "serviceAccount:${var.ci_email}"
-}
-
 resource "kubernetes_secret" "ci_config" {
   metadata {
     name = "ci-config"

--- a/infra/gcp/ci/variables.tf
+++ b/infra/gcp/ci/variables.tf
@@ -28,10 +28,6 @@ variable "ci_email" {
   type = string
 }
 
-variable "container_registry_id" {
-  type = string
-}
-
 variable "github_context" {
   type = string
 }


### PR DESCRIPTION
We have `use_artifact_registry=true` so these entries are unused anyway. With a recent terraform update, `google_container_registry.registry` is no longer populated. This leads to errors when running terraform, so it is time for these entries to be removed.

With this applied, we will be in a position to apply #364's changes.