### PR TITLE
Cherry-pick upstream combiner fix: Reorder LEN field to end of new ref entry struct

### DIFF
--- a/hail/python/hail/vds/combiner/combine.py
+++ b/hail/python/hail/vds/combiner/combine.py
@@ -100,7 +100,7 @@ def make_ref_entry_struct(e, entry_to_keep, row):
         hl.case()
         .when(
             e.GT.is_hom_ref(),
-            hl.struct(LEN=row.info.END - row.locus.position + 1, **reference_fields, **handled_fields),
+            hl.struct(**reference_fields, **handled_fields, LEN=row.info.END - row.locus.position + 1),
         )
         .or_error('found reference block with non reference-genotype at' + hl.str(row.locus))
     )


### PR DESCRIPTION
Cherry-pick upstream fix hail-is/hail#14897 to resolve incompatibility when running the combiner on a mixture of old and new datasets.

Context:

* https://centrepopgen.slack.com/archives/C018KFBCR1C/p1747790657229869
* https://hail.zulipchat.com/#narrow/channel/123010-Hail-Query-0.2E2-support/topic/gVCF.20combiner.20incompatibility.20since.200.2E2.2E134/with/519660370