### PR TITLE
Create requested JVM only when there aren't already enough

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -3046,8 +3046,11 @@ class Worker:
         while True:
             try:
                 requested_n_cores = self._waiting_for_jvm_with_n_cores.get_nowait()
-                log.info(f'Worker._initialize_jvms woke up for {requested_n_cores=}')
-                await self._jvmpools_by_cores[requested_n_cores].create_jvm()
+                if not self._jvmpools_by_cores[requested_n_cores].full():
+                    log.info(f'Worker._initialize_jvms woke up for {requested_n_cores=}, creating one')
+                    await self._jvmpools_by_cores[requested_n_cores].create_jvm()
+                else:
+                    log.info(f'Worker._initialize_jvms woke up for {requested_n_cores=}, already full')
                 log.info(f'Worker._initialize_jvms after wakeup JVM creation: {self._jvmpools_by_cores[requested_n_cores]!r}')
             except asyncio.QueueEmpty:
                 next_unfull_jvmpool = None


### PR DESCRIPTION
When many JVM-requiring jobs are starting at once, many requests will be queued up on _waiting_for_jvm_with_n_cores. There may in fact be more pending requests than max_jvms, so the excess requests should simply wait for an existing JVM to become available rather than cause another to be created.

(We'll leave all the existing debug logging in for now, while we validate whether this solves the problem. If it does, we'll remove most of the excess logging in a few days.)