### PR TITLE
Validate Scala token construction and further reduce result reading concurrency

### DIFF
--- a/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.core.StreamReadConstraints
 
 object ServiceBackend {
   // SET-982 2026-02-19 Reduced from 1000 to work around excessive driver memory use
-  val MaxAvailableGcsConnections = 300
+  val MaxAvailableGcsConnections = 100
 
   // See https://github.com/hail-is/hail/issues/14580
   StreamReadConstraints.overrideDefaultStreamReadConstraints(

--- a/hail/hail/src/is/hail/services/oauth2.scala
+++ b/hail/hail/src/is/hail/services/oauth2.scala
@@ -58,7 +58,9 @@ object oauth2 {
   case class GoogleCloudCredentials(value: GoogleCredentials) extends CloudCredentials {
     override def accessToken: String = {
       value.refreshIfExpired()
-      value.getAccessToken.getTokenValue
+      val token = value.getAccessToken.getTokenValue
+      assert(token != null && token.nonEmpty)
+      token
     }
 
     override def scoped(scopes: Array[String]): GoogleCloudCredentials =


### PR DESCRIPTION
Further workarounds and instrumentation for [SET-982.](https://cpg-populationanalysis.atlassian.net/browse/SET-982)

@michael-harper's recent batch shows:

```
2026-02-23 17:16:47.916 requests$: WARN: 401 GET http://batch.hail/api/v2alpha/batches/1126130/job-groups/82/jobs?q=state%3Dsuccess&last_job_id=0
401: Unauthorized
```

i.e., a request to the Batch API failed. Examination of the corresponding GCP logs show that the 401 request was missing a `hail_identity` field in the JSON payload. One way this could happen is for `value.getAccessToken.getTokenValue` to fail, which this `assert` will detect.

Also the Hail maintainers suggested reducing the result reading threading even further. 