### PR TITLE
Reduce Job._compile() parallelism from 150 to 50

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -800,7 +800,8 @@ class ServiceBackend(Backend[bc.Batch]):
 
             used_remote_tmpdir_results = await bounded_gather(
                 *[functools.partial(compile_job, j) for j in unsubmitted_jobs],
-                parallelism=150,
+                # JohnM 2026-05-25 Reduce from 150 as PythonJob._compile() uploads files to buckets
+                parallelism=50,
                 cancel_on_error=True,
             )
             used_remote_tmpdir |= any(used_remote_tmpdir_results)


### PR DESCRIPTION
For PythonJob, this involves uploading temporary files to GCS. At least until the aiotools Copier google API rewrite lands, reduce the number of these being run simultaneously.

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1779660592497319