### PR TITLE
Interim deployment to improve SourceCopier performance

### DIFF
--- a/hail/hail/src/is/hail/services/package.scala
+++ b/hail/hail/src/is/hail/services/package.scala
@@ -195,6 +195,7 @@ package object services extends Logging {
       catch {
         case e: Exception =>
           val delay = delayMsForTry(tries)
+
           if (tries <= 5 && isLimitedRetriesError(e)) {
             logger.warn(
               s"A limited retry error has occured. We will automatically retry " +
@@ -212,21 +213,18 @@ package object services extends Logging {
             }
           } else if (!isTransientError(e)) {
             throw e
-          } else if (tries % 10 == 0) {
+          }
+
+          if (tries % 10 == 9) {
+            // WARN is redirected to the python output. It might be useful to know that hail's
+            // encountering transient errors, but we don't want to spam the user with warnings.
             logger.warn(s"Encountered $tries transient errors, most recent one was $e.")
           }
+
+          logger.info(s"Attempt #$tries - $e")
           Thread.sleep(delay)
           reset.foreach(_())
           retry
       }
     }
-
-  def formatException(e: Throwable): String = {
-    using(new StringWriter()) { sw =>
-      using(new PrintWriter(sw)) { pw =>
-        e.printStackTrace(pw)
-        sw.toString
-      }
-    }
-  }
 }

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/logging_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/logging_client.py
@@ -24,7 +24,7 @@ class PagedEntryIterator:
 
         # in case a response is empty but there are more pages
         while True:
-            assert self._page
+            assert self._page is not None
             # an empty page has no entries
             if (
                 'entries' in self._page

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -246,22 +246,23 @@ class SourceCopier:
         return_exceptions: bool,
     ) -> None:
         try:
-            async with self.xfer_sema.acquire_manager(min(Copier.BUFFER_SIZE, this_part_size)):
-                async with await self.router_fs.open_from(
-                    srcfile, part_number * part_size, length=this_part_size
-                ) as srcf:
-                    async with await part_creator.create_part(
-                        part_number, part_number * part_size, size_hint=this_part_size
-                    ) as destf:
-                        n = this_part_size
-                        while n > 0:
-                            b = await srcf.read(min(Copier.BUFFER_SIZE, n))
-                            if len(b) == 0:
-                                raise UnexpectedEOFError()
-                            written = await destf.write(b)
-                            assert written == len(b)
-                            source_report.finish_bytes(written)
-                            n -= len(b)
+            async with self.xfer_sema.acquire_manager(Copier.BUFFER_SIZE):
+                async with await part_creator.create_part(
+                    part_number, part_number * part_size, size_hint=this_part_size
+                ) as destf:
+                    n = this_part_size
+                    while n > 0:
+                        bytes_to_write = min(Copier.BUFFER_SIZE, n)
+                        async with await self.router_fs.open_from(
+                            srcfile, part_number * part_size + (this_part_size - n), length=bytes_to_write
+                        ) as srcf:
+                            b = await srcf.readexactly(bytes_to_write)
+                        if len(b) == 0:
+                            raise UnexpectedEOFError()
+                        written = await destf.write(b)
+                        assert written == len(b)
+                        source_report.finish_bytes(written)
+                        n -= bytes_to_write
         except asyncio.TimeoutError:
             source_report.timeout()
             # This is an internal transient error, so ignore return_exceptions and always retry


### PR DESCRIPTION
This cherry-picks several improvements from the upstream upcoming release for deployment to CPG's Hail installation. Primarily improved input file localisation, and a couple of logging improvements coming along for the ride:

* Primarily a SourceCopier improvement to prevent excessive timeouts. (View this diff with indentation changes hidden.)
* Improved logging of Hail Query timeout exceptions.
* Preventing an AssertionError that pollutes the logs about once a minute.